### PR TITLE
Handle primitive map keys 

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -541,7 +541,6 @@ impl<'de> de::MapAccess<'de> for Deserializer {
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Error>
         where K: de::DeserializeSeed<'de>,
     {
-
         if let Some((key, value)) = self.iter.next() {
             self.value = Some(value);
             return seed.deserialize(key.into_deserializer()).map(Some);
@@ -579,7 +578,9 @@ macro_rules! deserialize_primitive {
                                                   stringify!($ty))))
                 },
                 Level::Flat(x) => {
-                    visitor.$visit_method(str::FromStr::from_str(&x).unwrap())
+                    let val = str::FromStr::from_str(&x)
+                        .map_err(|e| de::Error::custom(e))?;
+                    visitor.$visit_method(val)
                 },
                 Level::Invalid(e) => {
                     Err(de::Error::custom(e))

--- a/tests/test_deserialize.rs
+++ b/tests/test_deserialize.rs
@@ -175,6 +175,34 @@ fn qs_test_simple() {
 }
 
 #[test]
+fn qs_u32_map() {
+    #[derive(Debug,Serialize,Deserialize,PartialEq)]
+    struct Query {
+        map: HashMap<u32, String>
+    }
+
+    let query = {
+        let mut map = HashMap::new();
+        map.insert(10, "Hello".into());
+        Query { map: map }
+    };
+
+    let params: Query = qs::from_str("map[10]=Hello").unwrap();
+    assert_eq!(params, query)
+}
+
+#[test]
+fn no_panic_on_parse_error() {
+    #[derive(Debug,Serialize,Deserialize,PartialEq)]
+    struct Query {
+        vec: Vec<u32>
+    }
+
+    let params: Result<Query, _> = qs::from_str("vec[]=a&vec[]=2");
+    assert!(params.is_err())
+}
+
+#[test]
 fn qs_nesting() {
     // t.deepEqual(qs.parse('a[b]=c'), { a: { b: 'c' } }, 'parses a single
     // nested string');


### PR DESCRIPTION
and don't panic on parse error. Adds a `ParsableStringDeserializer` wrapper for Strings to handle primitive deserialization.