### PR TITLE
fix parse_seq_value not decoding '+' to ' '

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "samscott89/serde_qs"
 
 [dependencies]
 data-encoding = "1.2"
-error-chain = "0.10.0"
+error-chain = "0.11.0"
 dtoa = "0.4.0"
 fnv = "1.0.3"
 itoa = "0.3.0"

--- a/src/de/parse.rs
+++ b/src/de/parse.rs
@@ -277,7 +277,7 @@ impl<I: Iterator<Item = u8>> Parser<I> {
                     }
                     if let Level::Nested(ref mut map) = *node {
                         self.depth -= 1;
-                        self.parse(map.entry(key)
+                        let _ = self.parse(map.entry(key)
                                 .or_insert(Level::Invalid("uninitialised")))?;
                         Ok(())
                     } else {
@@ -301,7 +301,11 @@ impl<I: Iterator<Item = u8>> Parser<I> {
             b'=' => {
                 self.acc.clear();
                 for b in self.inner.by_ref().take_while(|b| b != &b'&') {
-                    self.acc.push(b);
+                    if b == b'+' {
+                        self.acc.push(b' ');
+                    } else {
+                        self.acc.push(b);
+                    }
                 }
                 let value = String::from_utf8(self.acc.split_off(0));
                 let value = value.map_err(Error::from)?;
@@ -350,7 +354,7 @@ impl<I: Iterator<Item = u8>> Parser<I> {
                     }
                     if let Level::OrderedSeq(ref mut map) = *node {
                         self.depth -= 1;
-                        self.parse(map.entry(key)
+                        let _ = self.parse(map.entry(key)
                                 .or_insert(Level::Invalid("uninitialised")))?;
                         Ok(())
                     } else {


### PR DESCRIPTION
I just ran into a case where `blah[]=Blah+Blah` included the `+` in the deserialized value. This PR just adds the block responsible for this decoding for `parse_seq_value` (it was already present for `parse_ord_seq_value` and `parse_map_value`).

I also updated the `error-chain` dependency to resolve an `unused_doc_comment`  issue and "fixed" a couple `unused_results`, both of which were preventing me from using the patch locally.