### PR TITLE
fix percent decoding issue

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -139,6 +139,14 @@ enum Level {
     Invalid(&'static str),
 }
 
+impl Level {
+    fn decode_to_string(bytes: &[u8]) -> String {
+        let decoded = percent_encoding::percent_decode(bytes);
+        decoded.decode_utf8_lossy().into_owned()
+    }
+}
+
+
 impl QsDeserializer {
     fn with_map(map: BTreeMap<String, Level>) -> Self {
         QsDeserializer {
@@ -149,8 +157,7 @@ impl QsDeserializer {
 
     /// Returns a new `QsDeserializer`.
     pub fn with_config(config: &Config, input: &[u8]) -> Self {
-        let decoded = percent_encoding::percent_decode(input);
-        parse::Parser::new(decoded, vec![], None, config.max_depth()).as_deserializer()
+        parse::Parser::new(input, vec![], None, config.max_depth()).as_deserializer()
 
     }
 }

--- a/tests/test_deserialize.rs
+++ b/tests/test_deserialize.rs
@@ -172,6 +172,12 @@ fn qs_test_simple() {
     );
     // st.end();
     // });
+
+    map_test!("foo=%24", "foo"["$"]);
+
+    map_test!("foo=%26", "foo"["&"]);
+
+    
 }
 
 


### PR DESCRIPTION
Fixes #10.

May add some slight overhead since `percent_decode` has to be called in multiple places, but this is the right thing to do.

All the string encoding is deferred until the percent encoding is performed.

Added a couple tests, one of which fails on master (but passes here).