### PR TITLE
use non-strict parsing to allow round-trip in example

### DIFF
--- a/examples/introduction.rs
+++ b/examples/introduction.rs
@@ -7,6 +7,8 @@ extern crate serde_urlencoded as urlencoded;
 use rand::Rng;
 use std::collections::HashMap;
 
+use qs::Config;
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 struct Address {
     city: String,
@@ -64,9 +66,15 @@ fn main() {
     // as a list of pairs using serde_urlencoded:
     let pairs: Vec<(String, String)> = urlencoded::from_str(&encoded).unwrap();
     println!("`serde_urlencoded` from_str to pairs:\n\t{:?}", pairs);
+
     // However, the best way is to use serde_qs to deserialize the entire thing
     // into a struct:
-    let params: QueryParams = qs::from_str(&encoded).unwrap();
+    //
+    // (For this round trip to work, it's necessary to parse the query string
+    // in non-strict mode, to allow parsing of url_encoded square brackets
+    // in the key).
+    let qs_non_strict = Config::new(5, false);
+    let params: QueryParams = qs_non_strict.deserialize_str(&encoded).unwrap();
     assert_eq!(params, example_params);
     println!("`serde_qs` from_str to struct:\n\t{:?}", params);
 


### PR DESCRIPTION
Currently, the example `introduction` fails with:
```
`serde_qs` to_string for map:
	user_ids%5B2%5D=3&user_ids%5B0%5D=1&name=Acme&address%5Bpostcode%5D=12345&user_ids%5B3%5D=4&user_ids%5B1%5D=2&phone=12345&id=42&address%5Bcity%5D=Carrot+City
`serde_urlencoded` to_string for map:
	user_ids%5B2%5D=3&user_ids%5B0%5D=1&name=Acme&address%5Bpostcode%5D=12345&user_ids%5B3%5D=4&user_ids%5B1%5D=2&phone=12345&id=42&address%5Bcity%5D=Carrot+City

`serde_urlencoded` from_str to pairs:
	[("user_ids[2]", "3"), ("user_ids[0]", "1"), ("name", "Acme"), ("address[postcode]", "12345"), ("user_ids[3]", "4"), ("user_ids[1]", "2"), ("phone", "12345"), ("id", "42"), ("address[city]", "Carrot City")]
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error(Custom("missing field `address`"), State { next_error: None, backtrace: None })', libcore/result.rs:945:5
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

From what I can tell, the issue is that the error happens when serde_qs attempts to parse in strict mode, which allows only square brackets in keys, but the input (from serializing) has url encoded square brackets in the keys.

I'm not sure how you want to handle this discrepancy, but I've provided a fix here where I complete the round trip by parsing in non-strict mode.