### PR TITLE
Add deserialization parameters to QsQueryConfig

### DIFF
--- a/tests/test_actix.rs
+++ b/tests/test_actix.rs
@@ -12,6 +12,7 @@ use actix_web::http::StatusCode;
 use actix_web::test::TestRequest;
 use actix_web::{FromRequest, HttpResponse};
 use qs::actix::{QsQuery, QsQueryConfig};
+use qs::Config as QsConfig;
 use serde::de::Error;
 
 fn from_str<'de, D, S>(deserializer: D) -> Result<S, D::Error>
@@ -87,6 +88,39 @@ fn test_composite_querystring_extractor() {
     let s = QsQuery::<Query>::from_request(&req, &mut pl).unwrap();
     assert_eq!(s.foo, 1);
     assert_eq!(s.bars, vec![0, 1]);
+    assert_eq!(s.common.limit, 100);
+    assert_eq!(s.common.offset, 50);
+    assert_eq!(s.common.remaining, true);
+}
+
+#[test]
+fn test_default_qs_config() {
+    let req = TestRequest::with_uri(
+        "/test?foo=1&bars%5B%5D=3&limit=100&offset=50&remaining=true",
+    )
+    .to_srv_request();
+    let (req, mut pl) = req.into_parts();
+
+    let e = QsQuery::<Query>::from_request(&req, &mut pl).unwrap_err();
+    assert_eq!(
+        e.as_response_error().error_response().status(),
+        StatusCode::BAD_REQUEST
+    );
+}
+
+#[test]
+fn test_custom_qs_config() {
+    let req = TestRequest::with_uri(
+        "/test?foo=1&bars%5B%5D=3&limit=100&offset=50&remaining=true",
+    )
+    .data(QsQueryConfig::default().qs_config(QsConfig::new(5, false)))
+    .to_srv_request();
+
+    let (req, mut pl) = req.into_parts();
+
+    let s = QsQuery::<Query>::from_request(&req, &mut pl).unwrap();
+    assert_eq!(s.foo, 1);
+    assert_eq!(s.bars, vec![3]);
     assert_eq!(s.common.limit, 100);
     assert_eq!(s.common.offset, 50);
     assert_eq!(s.common.remaining, true);


### PR DESCRIPTION
This allows switching to non-strict parsing mode

resolves #21