### PR TITLE
add actix-web version 2.0.0 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ version = "0.5.1"
 repository = "samscott89/serde_qs"
 
 [dependencies]
-actix-web = { version ="2.0.0", optional = true }
+actix-web = { package = "actix-web", version = "1.0.0", optional = true }
+actix-web2 = { package = "actix-web", version = "2.0.0", optional = true }
 futures = { version = "0.3", optional = true }
 data-encoding = "2.1.2"
 error-chain = "0.12.0"
@@ -31,7 +32,8 @@ serde_urlencoded = "0.5.4"
 
 [features]
 default = []
-actix = ["actix-web", "futures"]
+actix = ["actix-web"]
+actix2 = ["actix-web2", "futures"]
 
 [package.metadata.docs.rs]
 features = [ "actix" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ version = "0.5.1"
 repository = "samscott89/serde_qs"
 
 [dependencies]
-actix-web = { version ="1.0.0", optional = true }
+actix-web = { version ="2.0.0", optional = true }
+futures = { version = "0.3", optional = true }
 data-encoding = "2.1.2"
 error-chain = "0.12.0"
 percent-encoding = "1.0.1"
@@ -30,7 +31,7 @@ serde_urlencoded = "0.5.4"
 
 [features]
 default = []
-actix = ["actix-web"]
+actix = ["actix-web", "futures"]
 
 [package.metadata.docs.rs]
 features = [ "actix" ]

--- a/src/actix2.rs
+++ b/src/actix2.rs
@@ -2,12 +2,13 @@
 //!
 //! Enable with the `actix` feature.
 
-use actix_web::dev::Payload;
-use actix_web::{
+use actix_web2::dev::Payload;
+use actix_web2::{
     Error as ActixError, FromRequest, HttpRequest, HttpResponse, ResponseError,
 };
 use de::Config as QsConfig;
 use error::Error as QsError;
+use futures::future::{self, Ready};
 use serde::de;
 use std::fmt;
 use std::fmt::{Debug, Display};
@@ -88,7 +89,7 @@ where
     T: de::DeserializeOwned,
 {
     type Error = ActixError;
-    type Future = Result<Self, ActixError>;
+    type Future = Ready<Result<Self, ActixError>>;
     type Config = QsQueryConfig;
 
     #[inline]
@@ -103,18 +104,20 @@ where
             .map(|c| &c.qs_config)
             .unwrap_or(&default_qsconfig);
 
-        qsconfig
-            .deserialize_str::<T>(req.query_string())
-            .map(|val| Ok(QsQuery(val)))
-            .unwrap_or_else(move |e| {
-                let e = if let Some(error_handler) = error_handler {
-                    (error_handler)(e, req)
-                } else {
-                    e.into()
-                };
+        future::ready(
+            qsconfig
+                .deserialize_str::<T>(req.query_string())
+                .map(|val| Ok(QsQuery(val)))
+                .unwrap_or_else(move |e| {
+                    let e = if let Some(error_handler) = error_handler {
+                        (error_handler)(e, req)
+                    } else {
+                        e.into()
+                    };
 
-                Err(e)
-            })
+                    Err(e)
+                }),
+        )
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,6 +206,8 @@
 #[cfg(feature = "actix")]
 extern crate actix_web;
 extern crate data_encoding;
+#[cfg(feature = "actix")]
+extern crate futures;
 #[macro_use]
 extern crate error_chain;
 extern crate percent_encoding;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,8 +205,10 @@
 
 #[cfg(feature = "actix")]
 extern crate actix_web;
+#[cfg(feature = "actix2")]
+extern crate actix_web2;
 extern crate data_encoding;
-#[cfg(feature = "actix")]
+#[cfg(feature = "actix2")]
 extern crate futures;
 #[macro_use]
 extern crate error_chain;
@@ -216,6 +218,8 @@ extern crate serde;
 
 #[cfg(feature = "actix")]
 pub mod actix;
+#[cfg(feature = "actix2")]
+pub mod actix2;
 mod de;
 mod error;
 mod ser;


### PR DESCRIPTION
This pull request adds a new feature to serde_qs, specifically the feature "actix2". This new feature is exactly like the "actix" feature, but with actix-web version 2.0 support instead. 