### PR TITLE
Fix deserializing empty sequences

### DIFF
--- a/src/de/parse.rs
+++ b/src/de/parse.rs
@@ -333,6 +333,11 @@ impl<'a> Parser<'a> {
                             }
                         }
                     }
+                    // Skip empty byte sequences (e.g. leading `&`, trailing `&`, `&&`, ...)
+                    b'&' => {
+                        self.clear_acc();
+                        Ok(true)
+                    }
                     // This means the key should be a root key
                     // of the form "abc" or "abc[..=]"
                     // We do actually allow integer keys here since they cannot

--- a/tests/test_deserialize.rs
+++ b/tests/test_deserialize.rs
@@ -124,6 +124,12 @@ fn qs_test_simple() {
     // st.deepEqual(qs.parse('0=foo'), { 0: 'foo' });
     map_test!("0=foo", 0["foo"]);
 
+    // st.deepEqual(qs.parse('&0=foo'), { 0: 'foo' });
+    map_test!("&0=foo", 0["foo"]);
+
+    // st.deepEqual(qs.parse('0=foo&'), { 0: 'foo' });
+    map_test!("0=foo&", 0["foo"]);
+
     // st.deepEqual(qs.parse('foo=c++'), { foo: 'c  ' });
     map_test!("foo=c++", "foo"["c  "]);
 
@@ -158,6 +164,9 @@ fn qs_test_simple() {
 
     // st.deepEqual(qs.parse('foo=bar&bar=baz'), { foo: 'bar', bar: 'baz' });
     map_test!("foo=bar&bar=baz", "foo"["bar"] "bar"["baz"]);
+
+    // st.deepEqual(qs.parse('foo=bar&&bar=baz'), { foo: 'bar', bar: 'baz' });
+    map_test!("foo=bar&&bar=baz", "foo"["bar"] "bar"["baz"]);
 
     // st.deepEqual(qs.parse('foo2=bar2&baz2='), { foo2: 'bar2', baz2: '' });
     map_test!("foo2=bar2&baz2=", "foo2"["bar2"] "baz2"[""]);


### PR DESCRIPTION
Hi, I've noticed that `serde_qs`
- fails to parse querystrings starting with an ampersand `&` (e.g. `&foo=bar`), and
- parses something like `a=b&&c=d` as `{ "a": "b", "&c": "d" }`

Those two cases are fixed by this PR. 

If I understand [the spec](https://url.spec.whatwg.org/#urlencoded-parsing) correctly, a `&` at the start, at the end, or an `&&` should be perfectly fine. Those empty byte sequences after splitting by `&` should simply be ignored.

Thanks in advance for considering this change!
