### PR TITLE
Bump actix version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ version = "0.7.0"
 repository = "samscott89/serde_qs"
 
 [dependencies]
-actix-web = { version = "2.0", optional = true }
+actix-web = { version = "3.0.1", optional = true }
 data-encoding = "2.2.1"
 futures = { version = "0.3", optional = true } 
 percent-encoding = "2.1.0"


### PR DESCRIPTION
Not sure if this will cause errors for versions of actix-web < 3.0.1. If so I would be happy to implement actix-web 3.0 as a feature on the crate.