### PR TITLE
Support enum unit variants as map keys

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -654,6 +654,18 @@ impl<'de> de::Deserializer<'de> for ParsableStringDeserializer<'de> {
         self.0.into_deserializer().deserialize_any(visitor)
     }
 
+    fn deserialize_enum<V>(
+        self,
+        _: &'static str,
+        _: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_enum(LevelDeserializer(Level::Flat(self.0)))
+    }
+
     forward_to_deserialize_any! {
         map
         struct
@@ -670,7 +682,6 @@ impl<'de> de::Deserializer<'de> for ParsableStringDeserializer<'de> {
         tuple_struct
         identifier
         tuple
-        enum
         ignored_any
     }
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -524,14 +524,13 @@ impl ser::Serializer for StringSerializer {
         Err(Error::Unsupported)
     }
 
-    /// Returns an error.
     fn serialize_unit_variant(
         self,
         _name: &'static str,
         _variant_index: u32,
-        _variant: &'static str,
+        variant: &'static str,
     ) -> Result<Self::Ok> {
-        Err(Error::Unsupported)
+        Ok(variant.to_string())
     }
 
     /// Returns an error.

--- a/tests/test_deserialize.rs
+++ b/tests/test_deserialize.rs
@@ -640,5 +640,23 @@ fn deserialize_plus() {
 
 #[test]
 fn deserialize_vec_of_structs() {
+}
 
+#[test]
+fn deserialize_map_with_unit_enum_keys() {
+    #[derive(Deserialize, Eq, PartialEq, Hash)]
+    enum Operator {
+        Lt,
+        Gt,
+    }
+
+    #[derive(Deserialize)]
+    struct Filter {
+        point: HashMap<Operator, u64>,
+    }
+
+    let test: Filter = serde_qs::from_str("point[Gt]=123&point[Lt]=321").unwrap();
+
+    assert_eq!(test.point[&Operator::Gt], 123);
+    assert_eq!(test.point[&Operator::Lt], 321);
 }

--- a/tests/test_serialize.rs
+++ b/tests/test_serialize.rs
@@ -131,3 +131,28 @@ fn serialize_flatten() {
     let rec_params = qs::to_string(&query).unwrap();
     assert_eq!(rec_params, params);
 }
+
+#[test]
+fn serialize_map_with_unit_enum_keys() {
+    use std::collections::HashMap;
+
+    #[derive(Serialize, Eq, PartialEq, Hash)]
+    enum Operator {
+        Lt,
+        Gt,
+    }
+
+    #[derive(Serialize)]
+    struct Filter {
+        point: HashMap<Operator, u64>,
+    }
+
+    let mut map = HashMap::new();
+    map.insert(Operator::Gt, 123);
+    map.insert(Operator::Lt, 321);
+    let test = Filter { point: map };
+
+    let query = qs::to_string(&test).unwrap();
+
+    assert!(query == "point[Lt]=321&point[Gt]=123" || query == "point[Gt]=123&point[Lt]=321");
+}


### PR DESCRIPTION
Closes #36 

I also wrote the tests covering these changes, but didn't change the documentations.