### PR TITLE
Add warp support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,8 @@ futures = { version = "0.3.8", optional = true }
 percent-encoding = "2.1.0"
 serde = "1.0.118"
 thiserror = "1.0.22"
-warp = { version = "0.3", default-features = false, optional = true }
+tracing = { version = "0.1", optional = true }
+warp-framework = { package = "warp", version = "0.3", default-features = false, optional = true }
 
 [dev-dependencies]
 csv = "1.1.5"
@@ -35,6 +36,7 @@ serde_urlencoded = "0.7.0"
 default = []
 actix = ["actix-web", "futures"]
 actix2 = ["actix-web2", "futures"]
+warp = [ "futures", "tracing", "warp-framework" ]
 
 [package.metadata.docs.rs]
 features = [ "actix", "warp" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ futures = { version = "0.3.8", optional = true }
 percent-encoding = "2.1.0"
 serde = "1.0.118"
 thiserror = "1.0.22"
+warp = { version = "0.3", default-features = false, optional = true }
 
 [dev-dependencies]
 csv = "1.1.5"
@@ -36,4 +37,4 @@ actix = ["actix-web", "futures"]
 actix2 = ["actix-web2", "futures"]
 
 [package.metadata.docs.rs]
-features = [ "actix" ]
+features = [ "actix", "warp" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,17 @@
 //! }
 //! ```
 //!
+//! ## Use with `warp` filters
+//!
+//! The `warp` feature enables the use of `serde_qs::warp::query()`, which
+//! is a direct substitute for the `warp::query::query()` filter and can be used like this:
+//!
+//! ```ignore
+//! serde_qs::warp::query().and_then(|info| async move {
+//!    Ok::<_, Rejection>(format!("Welcome {}!", info.username))
+//! });
+//! ```
+//!
 //! Support for `actix-web 2.0.0` is available via the `actix2` feature.
 
 #[macro_use]
@@ -168,6 +179,8 @@ pub mod actix;
 mod de;
 mod error;
 mod ser;
+#[cfg(feature = "warp")]
+pub mod warp;
 
 #[doc(inline)]
 pub use de::Config;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,8 @@
 //! serde_qs::warp::query(Config::default())
 //!     .and_then(|info| async move {
 //!         Ok::<_, Rejection>(format!("Welcome {}!", info.username))
-//!     });
+//!     })
+//!     .recover(serde_qs::warp::recover_fn);
 //! ```
 //!
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,10 +158,12 @@
 //! }
 //! ```
 //!
+//! Support for `actix-web 2.0.0` is available via the `actix2` feature.
+//!
 //! ## Use with `warp` filters
 //!
 //! The `warp` feature enables the use of `serde_qs::warp::query()`, which
-//! is a direct substitute for the `warp::query::query()` filter and can be used like this:
+//! is a substitute for the `warp::query::query()` filter and can be used like this:
 //!
 //! ```ignore
 //! serde_qs::warp::query(Config::default())
@@ -170,7 +172,6 @@
 //!     });
 //! ```
 //!
-//! Support for `actix-web 2.0.0` is available via the `actix2` feature.
 
 #[macro_use]
 extern crate serde;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,9 +164,10 @@
 //! is a direct substitute for the `warp::query::query()` filter and can be used like this:
 //!
 //! ```ignore
-//! serde_qs::warp::query().and_then(|info| async move {
-//!    Ok::<_, Rejection>(format!("Welcome {}!", info.username))
-//! });
+//! serde_qs::warp::query(Config::default())
+//!     .and_then(|info| async move {
+//!         Ok::<_, Rejection>(format!("Welcome {}!", info.username))
+//!     });
 //! ```
 //!
 //! Support for `actix-web 2.0.0` is available via the `actix2` feature.

--- a/src/warp.rs
+++ b/src/warp.rs
@@ -1,3 +1,7 @@
+//! Functionality for using `serde_qs` with `warp`.
+//!
+//! Enable with the `warp` feature.
+
 use crate::{de::Config as QsConfig, error};
 use serde::de;
 use std::sync::Arc;

--- a/src/warp.rs
+++ b/src/warp.rs
@@ -1,0 +1,46 @@
+use crate::{de::Config as QsConfig, error};
+use serde::de;
+use std::sync::Arc;
+use warp::{reject::Reject, Filter, Rejection};
+
+impl Reject for error::Error {}
+
+/// Extract typed information from from the request's query.
+///
+/// ## Example
+///
+/// ```rust
+/// # #[macro_use] extern crate serde_derive;
+/// use warp::Filter;
+/// use serde_qs::Config;
+///
+/// #[derive(Deserialize)]
+/// pub struct UsersFilter {
+///    id: Vec<u64>,
+/// }
+///
+/// fn main() {
+///     let filter = serde_qs::warp::query(Config::default())
+///         .and_then(|info: UsersFilter| async move {
+///             Ok::<_, warp::Rejection>(
+///                 info.id.iter().map(|i| i.to_string()).collect::<Vec<String>>().join(", ")
+///             )
+///         });
+/// }
+/// ```
+pub fn query<T>(config: QsConfig) -> impl Filter<Extract = (T,), Error = Rejection> + Clone
+where
+    T: de::DeserializeOwned,
+{
+    let config = Arc::new(config);
+
+    warp::query::raw().and_then(move |query: String| {
+        let config = Arc::clone(&config);
+
+        async move {
+            config
+                .deserialize_str(query.as_str())
+                .map_err(Rejection::from)
+        }
+    })
+}

--- a/tests/test_warp.rs
+++ b/tests/test_warp.rs
@@ -1,0 +1,104 @@
+#![cfg(feature = "warp")]
+
+extern crate serde;
+
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_qs as qs;
+extern crate warp_framework as warp;
+
+use qs::Config as QsConfig;
+use serde::de::Error;
+use warp::{http::StatusCode, Filter};
+
+fn from_str<'de, D, S>(deserializer: D) -> Result<S, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    S: std::str::FromStr,
+{
+    let s = <&str as serde::Deserialize>::deserialize(deserializer)?;
+    S::from_str(&s).map_err(|_| D::Error::custom("could not parse string"))
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+struct Query {
+    foo: u64,
+    bars: Vec<u64>,
+    #[serde(flatten)]
+    common: CommonParams,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+struct CommonParams {
+    #[serde(deserialize_with = "from_str")]
+    limit: u64,
+    #[serde(deserialize_with = "from_str")]
+    offset: u64,
+    #[serde(deserialize_with = "from_str")]
+    remaining: bool,
+}
+
+#[test]
+fn test_default_error_handler() {
+    futures::executor::block_on(async {
+        let filter = qs::warp::query::<Query>(QsConfig::default())
+            .map(|_| "")
+            .recover(qs::warp::recover_fn);
+
+        let resp = warp::test::request().path("/test").reply(&filter).await;
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    })
+}
+
+#[test]
+fn test_composite_querystring_extractor() {
+    futures::executor::block_on(async {
+        let filter = qs::warp::query::<Query>(QsConfig::default());
+        let s = warp::test::request()
+            .path("/test?foo=1&bars[]=0&bars[]=1&limit=100&offset=50&remaining=true")
+            .filter(&filter)
+            .await
+            .unwrap();
+
+        assert_eq!(s.foo, 1);
+        assert_eq!(s.bars, vec![0, 1]);
+        assert_eq!(s.common.limit, 100);
+        assert_eq!(s.common.offset, 50);
+        assert_eq!(s.common.remaining, true);
+    })
+}
+
+#[test]
+fn test_default_qs_config() {
+    futures::executor::block_on(async {
+        let filter = qs::warp::query::<Query>(QsConfig::default())
+            .map(|_| "")
+            .recover(qs::warp::recover_fn);
+
+        let resp = warp::test::request()
+            .path("/test?foo=1&bars%5B%5D=3&limit=100&offset=50&remaining=true")
+            .reply(&filter)
+            .await;
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    })
+}
+
+#[test]
+fn test_custom_qs_config() {
+    futures::executor::block_on(async {
+        let filter = qs::warp::query::<Query>(QsConfig::new(5, false));
+        let s = warp::test::request()
+            .path("/test?foo=1&bars%5B%5D=3&limit=100&offset=50&remaining=true")
+            .filter(&filter)
+            .await
+            .unwrap();
+
+        assert_eq!(s.foo, 1);
+        assert_eq!(s.bars, vec![3]);
+        assert_eq!(s.common.limit, 100);
+        assert_eq!(s.common.offset, 50);
+        assert_eq!(s.common.remaining, true);
+    })
+}


### PR DESCRIPTION
Adds support for the warp framework

Having to add the `.recover()` function is unintuitive but I'm not aware of a better solution  

However, the recover function is not *strictly* necessary. It turns the `Rejection`, which would result in a `500 Internal Server Error`, into a `400 Bad Request` 
