### PR TITLE
Fixes #45 - encoding not working correctly on maps

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -122,13 +122,15 @@ fn replace_space(input: &str) -> Cow<str> {
 
 impl<'a, W: 'a + Write> QsSerializer<'a, W> {
     fn extend_key(&mut self, newkey: &str) {
-        let newkey = percent_encode(newkey.as_bytes(), QS_ENCODE_SET).collect::<Cow<str>>();
+        let newkey = percent_encode(newkey.as_bytes(), QS_ENCODE_SET)
+            .map(replace_space)
+            .collect::<String>();
         let key = if let Some(ref key) = self.key {
             format!("{}[{}]", key, newkey).into()
         } else {
             newkey.to_owned()
         };
-        self.key = Some(key)
+        self.key = Some(Cow::Owned(key))
     }
 
     fn write_value(&mut self, value: &[u8]) -> Result<()> {

--- a/tests/test_serialize.rs
+++ b/tests/test_serialize.rs
@@ -178,3 +178,24 @@ fn serialize_bytes() {
     let s = qs::to_string(&Query { bytes }).unwrap();
     assert_eq!(s, "bytes=hello%2C+world%21");
 }
+
+#[test]
+fn serialize_hashmap_keys() {
+    // Issue: https://github.com/samscott89/serde_qs/issues/45
+
+    #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+    struct HashParams {
+        attrs: std::collections::HashMap<String, String>,
+    }
+
+    let data = HashParams {
+        attrs: vec![
+            ("key 1!".to_owned(), "val 1".to_owned()),
+            ("key 2!".to_owned(), "val 2".to_owned()),
+        ]
+        .into_iter()
+        .collect(),
+    };
+    let s = qs::to_string(&data).unwrap();
+    assert!(s == "attrs[key+1%21]=val+1&attrs[key+2%21]=val+2" || s == "attrs[key+2%21]=val+2&attrs[key+1%21]=val+1");
+}


### PR DESCRIPTION
This PR fixes issue #45 by ensuring that keys go through same encoding steps as values.