### PR TITLE
Add actix-4 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 version = "0.8.3"
 
 [dependencies]
-actix-web = { version = "4.0.0-beta.6", optional = true, package = "actix-web" }
+actix-web = { version = "4.0.0-beta.10", optional = true, package = "actix-web" }
 actix-web3 = { version = "3.3.2", optional = true, package = "actix-web" }
 actix-web2 = { package = "actix-web", version = "2.0.0", optional = true }
 futures = { version = "0.3.13", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ readme = "README.md"
 version = "0.8.3"
 
 [dependencies]
-actix-web = { version = "3.3.2", optional = true, package = "actix-web" }
+actix-web = { version = "4.0.0-beta.6", optional = true, package = "actix-web" }
+actix-web3 = { version = "3.3.2", optional = true, package = "actix-web" }
 actix-web2 = { package = "actix-web", version = "2.0.0", optional = true }
 futures = { version = "0.3.13", optional = true }
 percent-encoding = "2.1.0"
@@ -30,6 +31,7 @@ serde_urlencoded = "0.7.0"
 [features]
 default = []
 actix = ["actix-web", "futures"]
+actix3 = ["actix-web3", "futures"]
 actix2 = ["actix-web2", "futures"]
 warp = [ "futures", "tracing", "warp-framework" ]
 

--- a/src/actix.rs
+++ b/src/actix.rs
@@ -7,6 +7,8 @@ use crate::error::Error as QsError;
 
 #[cfg(feature = "actix")]
 use actix_web;
+#[cfg(feature = "actix3")]
+use actix_web3 as actix_web;
 #[cfg(feature = "actix2")]
 use actix_web2 as actix_web;
 

--- a/src/actix.rs
+++ b/src/actix.rs
@@ -58,7 +58,7 @@ impl ResponseError for QsError {
 ///            .route(web::get().to(filter_users)));
 /// }
 /// ```
-pub struct QsQuery<T>(T);
+pub struct QsQuery<T>(pub T);
 
 impl<T> Deref for QsQuery<T> {
     type Target = T;

--- a/src/actix.rs
+++ b/src/actix.rs
@@ -21,9 +21,17 @@ use std::fmt::{Debug, Display};
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
+#[cfg(any(feature = "actix2", feature = "actix3"))]
 impl ResponseError for QsError {
     fn error_response(&self) -> HttpResponse {
         HttpResponse::BadRequest().finish()
+    }
+}
+
+// #[cfg(not(any(feature = "actix2", feature = "actix3")))]
+impl ResponseError for QsError {
+    fn status_code(&self) -> actix_web::http::StatusCode {
+        actix_web::http::StatusCode::BAD_REQUEST
     }
 }
 

--- a/src/actix.rs
+++ b/src/actix.rs
@@ -28,7 +28,7 @@ impl ResponseError for QsError {
     }
 }
 
-// #[cfg(not(any(feature = "actix2", feature = "actix3")))]
+#[cfg(not(any(feature = "actix2", feature = "actix3")))]
 impl ResponseError for QsError {
     fn status_code(&self) -> actix_web::http::StatusCode {
         actix_web::http::StatusCode::BAD_REQUEST
@@ -57,7 +57,7 @@ impl ResponseError for QsError {
 /// // Use `QsQuery` extractor for query information.
 /// // The correct request for this handler would be `/users?id[]=1124&id[]=88"`
 /// fn filter_users(info: QsQuery<UsersFilter>) -> HttpResponse {
-///     info.id.iter().map(|i| i.to_string()).collect::<Vec<String>>().join(", ").into()
+///     HttpResponse::Ok().body(info.id.iter().map(|i| i.to_string()).collect::<Vec<String>>().join(", "))
 /// }
 ///
 /// fn main() {
@@ -107,6 +107,7 @@ where
 {
     type Error = ActixError;
     type Future = Ready<Result<Self, ActixError>>;
+    #[cfg(any(feature = "actix2", feature = "actix3"))]
     type Config = QsQueryConfig;
 
     #[inline]
@@ -145,7 +146,7 @@ where
 /// # #[cfg(feature = "actix2")]
 /// # use actix_web2 as actix_web;
 /// use actix_web::{error, web, App, FromRequest, HttpResponse};
-/// use serde_qs::actix::QsQuery;
+/// use serde_qs::actix::{QsQuery, QsQueryConfig};
 /// use serde_qs::Config as QsConfig;
 ///
 /// #[derive(Deserialize)]
@@ -155,20 +156,20 @@ where
 ///
 /// /// deserialize `Info` from request's querystring
 /// fn index(info: QsQuery<Info>) -> HttpResponse {
-///     format!("Welcome {}!", info.username).into()
+///     HttpResponse::Ok().body(format!("Welcome {}!", info.username))
 /// }
 ///
 /// fn main() {
 ///     let app = App::new().service(
 ///         web::resource("/index.html").app_data(
 ///             // change query extractor configuration
-///             QsQuery::<Info>::configure(|cfg| {
-///                 cfg.error_handler(|err, req| {  // <- create custom error response
+///             QsQueryConfig::default()
+///                 .error_handler(|err, req| {  // <- create custom error response
 ///                     error::InternalError::from_response(
 ///                         err, HttpResponse::Conflict().finish()).into()
 ///                 })
 ///                 .qs_config(QsConfig::default())
-///             }))
+///             )
 ///             .route(web::post().to(index))
 ///     );
 /// }


### PR DESCRIPTION
Totally fine if you want to close this or wait for the final actix-web 4.0 release, but one of my projects is using actix-web 4-beta and I wanted to use QsQuery, so I made the fork and figured I'd send it upstream.

One other thing I did was make the `QsQuery` type have a public member -- this is how the `Query` type is in actix-web and makes unit-testing routes easier. You can also pattern match on the contents of QsQuery now.

Also up to you if you want to drop the actix2 feature at this point. I've kept it for now.