### PR TITLE
Fix empty output in csv_vectors example

### DIFF
--- a/examples/csv_vectors.rs
+++ b/examples/csv_vectors.rs
@@ -3,9 +3,7 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_qs as qs;
-
 use serde::de::DeserializeOwned;
-
 use std::default::Default;
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -24,21 +22,25 @@ fn main() {
 fn from_csv<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
 where
     D: serde::Deserializer<'de>,
-    T: DeserializeOwned,
+    T: DeserializeOwned + std::str::FromStr,
+    <T as std::str::FromStr>::Err: std::fmt::Debug,
 {
     deserializer.deserialize_str(CSVVecVisitor::<T>::default())
 }
 
 /// Visits a string value of the form "v1,v2,v3" into a vector of bytes Vec<u8>
-struct CSVVecVisitor<T: DeserializeOwned>(std::marker::PhantomData<T>);
+struct CSVVecVisitor<T: DeserializeOwned + std::str::FromStr>(std::marker::PhantomData<T>);
 
-impl<T: DeserializeOwned> Default for CSVVecVisitor<T> {
+impl<T: DeserializeOwned + std::str::FromStr> Default for CSVVecVisitor<T> {
     fn default() -> Self {
         CSVVecVisitor(std::marker::PhantomData)
     }
 }
 
-impl<'de, T: DeserializeOwned> serde::de::Visitor<'de> for CSVVecVisitor<T> {
+impl<'de, T: DeserializeOwned + std::str::FromStr> serde::de::Visitor<'de> for CSVVecVisitor<T>
+where
+    <T as std::str::FromStr>::Err: std::fmt::Debug, // handle the parse error in a generic way
+{
     type Value = Vec<T>;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -49,12 +51,31 @@ impl<'de, T: DeserializeOwned> serde::de::Visitor<'de> for CSVVecVisitor<T> {
     where
         E: serde::de::Error,
     {
+        // Treat the comma-separated string as a single record in a CSV.
+        let mut rdr = csv::ReaderBuilder::new()
+            .has_headers(false)
+            .from_reader(s.as_bytes());
+
+        // Try to get the record and collect its values into a vector.
         let mut output = Vec::new();
-        let mut items = csv::Reader::from_reader(s.as_bytes());
-        for res in items.deserialize() {
-            let item: T = res
-                .map_err(|e| E::custom(format!("could not deserialize sequence value: {:?}", e)))?;
-            output.push(item);
+        for result in rdr.records() {
+            match result {
+                Ok(record) => {
+                    for field in record.iter() {
+                        output.push(
+                            field
+                                .parse::<T>()
+                                .map_err(|_| E::custom("Failed to parse field"))?,
+                        );
+                    }
+                }
+                Err(e) => {
+                    return Err(E::custom(format!(
+                        "could not deserialize sequence value: {:?}",
+                        e
+                    )));
+                }
+            }
         }
 
         Ok(output)


### PR DESCRIPTION
I found that `cargo run --example csv_vectors` produced incorrect output:
```rust
Query { r: [], s: 12 }
```

Where, based on the example, I expected:
```rust
Query { r: [1, 2, 3], s: 12 }
```

I believe the `csv::Reader::from_reader` function expects data where each line is a record. However, in the example, all values are on a single line, so the CSV reader treats them as columns of a single record.

I adjusted the from_csv function's trait bounds to ensure that T can be both deserialized and converted from a string. I also revamped the CSV parsing using ReaderBuilder for a bit more flexibility.

This new implementation produces the expected output.