### PR TITLE
Add `Deserializer::new` to crate a new deserializer, and public deserializer.

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -189,7 +189,7 @@ pub fn from_str<'de, T: de::Deserialize<'de>>(input: &'de str) -> Result<T> {
 /// A deserializer for the querystring format.
 ///
 /// Supported top-level outputs are structs and maps.
-pub(crate) struct QsDeserializer<'a> {
+pub struct QsDeserializer<'a> {
     iter: IntoIter<Cow<'a, str>, Level<'a>>,
     value: Option<Level<'a>>,
 }
@@ -215,6 +215,10 @@ impl<'a> QsDeserializer<'a> {
     /// Returns a new `QsDeserializer<'a>`.
     fn with_config(config: &Config, input: &'a [u8]) -> Result<Self> {
         parse::Parser::new(input, config.max_depth(), config.strict).as_deserializer()
+    }
+
+    pub fn new(input: &'a [u8]) -> Result<Self> {
+        Self::with_config(&Config::default(), input)
     }
 }
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -213,7 +213,7 @@ impl<'a> QsDeserializer<'a> {
     }
 
     /// Returns a new `QsDeserializer<'a>`.
-    fn with_config(config: &Config, input: &'a [u8]) -> Result<Self> {
+    pub fn with_config(config: &Config, input: &'a [u8]) -> Result<Self> {
         parse::Parser::new(input, config.max_depth(), config.strict).as_deserializer()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,9 +207,9 @@ mod ser;
 pub(crate) mod utils;
 
 #[doc(inline)]
-pub use de::Config;
-#[doc(inline)]
 pub use de::{from_bytes, from_str};
+#[doc(inline)]
+pub use de::{Config, QsDeserializer as Deserializer};
 pub use error::Error;
 #[doc(inline)]
 pub use ser::{to_string, to_writer, Serializer};


### PR DESCRIPTION
We use `serde_qs` for a custom `DeserializeSeed`.

`ValueDeserializer` is my Deserializer. 

```rs
let input = "title=Hello";
// ValueDeserializer is a custom DeserializeSeed
let deserializer = ValueDeserializer::new();
let de = serde_qs::Deserializer::new(input.as_bytes()).expect("parse QueryString failed");
let value = deserializer.deserialize(de).expect("parse QueryString failed");
```

This PR just make `QsDeserializer` pub as `Deserializer` and add a `new` method to create a Deserializer.

Like serde_yaml and serde_json:

- https://docs.rs/serde_yaml/latest/serde_yaml/struct.Deserializer.html
- https://docs.rs/serde_json/latest/serde_json/struct.Deserializer.html#method.from_str