### PR TITLE
Add QsForm Extractor for Actix

### DIFF
--- a/src/actix.rs
+++ b/src/actix.rs
@@ -76,7 +76,6 @@ impl ResponseError for QsError {
 /// ```
 pub struct QsQuery<T>(T);
 
-// let foo: T = QsQuery<T>.into_inner()
 impl<T> QsQuery<T> {
     /// Unwrap into inner T value
     pub fn into_inner(self) -> T {

--- a/src/actix.rs
+++ b/src/actix.rs
@@ -76,14 +76,10 @@ impl ResponseError for QsError {
 /// ```
 pub struct QsQuery<T>(T);
 
-pub trait IntoInner<T> {
-    fn into_inner(self) -> T;
-}
-
 // let foo: T = QsQuery<T>.into_inner()
-impl<T> IntoInner<T> for QsQuery<T> {
+impl<T> QsQuery<T> {
     /// Unwrap into inner T value
-    fn into_inner(self) -> T {
+    pub fn into_inner(self) -> T {
         self.0
     }
 }
@@ -264,10 +260,11 @@ impl Default for QsQueryConfig {
 #[derive(Debug)]
 pub struct QsForm<T>(T);
 
+
 // let foo: T = QsQuery<T>.into_inner()
-impl<T> IntoInner<T> for QsForm<T> {
+impl<T> QsForm<T> {
     /// Unwrap into inner T value
-    fn into_inner(self) -> T {
+    pub fn into_inner(self) -> T {
         self.0
     }
 }

--- a/src/actix.rs
+++ b/src/actix.rs
@@ -16,7 +16,8 @@ use actix_web::dev::Payload;
 #[cfg(any(feature = "actix2", feature = "actix3"))]
 use actix_web::HttpResponse;
 use actix_web::{Error as ActixError, FromRequest, HttpRequest, ResponseError};
-use futures::future::{ready, Ready};
+use futures::future::{ready, Ready, LocalBoxFuture, FutureExt};
+use futures::StreamExt;
 use serde::de;
 use std::fmt;
 use std::fmt::{Debug, Display};
@@ -73,6 +74,13 @@ impl ResponseError for QsError {
 /// }
 /// ```
 pub struct QsQuery<T>(T);
+
+impl<T> QsForm<T> {
+    /// Unwrap into inner `T` value.
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
 
 impl<T> Deref for QsQuery<T> {
     type Target = T;
@@ -218,6 +226,13 @@ impl Default for QsQueryConfig {
 #[derive(Debug)]
 pub struct QsForm<T>(T);
 
+impl<T> QsForm<T> {
+    /// Unwrap into inner `T` value.
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
 impl<T> Deref for QsForm<T> {
     type Target = T;
 
@@ -240,7 +255,7 @@ where
     T: DeserializeOwned + Debug,
 {
     type Error = ActixError;
-    type Config = ();
+    // type Config = ();
     type Future = LocalBoxFuture<'static, Result<Self, ActixError>>;
 
     fn from_request(req: &HttpRequest, payload: &mut Payload) -> Self::Future {

--- a/src/actix.rs
+++ b/src/actix.rs
@@ -214,3 +214,68 @@ impl Default for QsQueryConfig {
         }
     }
 }
+
+#[derive(Debug)]
+pub struct QsForm<T>(T);
+
+impl<T> Deref for QsForm<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for QsForm<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
+// See:
+// - https://github.com/actix/actix-web/blob/master/src/types/form.rs
+// - https://github.com/samscott89/serde_qs/blob/main/src/actix.rs
+impl<T> FromRequest for QsForm<T>
+where
+    T: DeserializeOwned + Debug,
+{
+    type Error = ActixError;
+    type Config = ();
+    type Future = LocalBoxFuture<'static, Result<Self, ActixError>>;
+
+    fn from_request(req: &HttpRequest, payload: &mut Payload) -> Self::Future {
+        let mut stream = payload.take();
+        let req_clone = req.clone();
+
+        async move {
+            let mut bytes = web::BytesMut::new();
+            
+            while let Some(item) = stream.next().await {
+                bytes.extend_from_slice(&item.unwrap());
+            }
+            
+            let query_config = req_clone.app_data::<QsQueryConfig>().clone();
+            let error_handler = query_config.map(|c| c.ehandler.clone()).unwrap_or(None);
+
+            let default_qsconfig = QsConfig::default();
+            let qsconfig = query_config
+                .map(|c| &c.qs_config)
+                .unwrap_or(&default_qsconfig);
+
+            qsconfig
+                .deserialize_bytes::<T>(&bytes)
+                .map(|val| Ok(QsForm(val)))
+                .unwrap_or_else(|e| {
+                    let e = if let Some(error_handler) = error_handler {
+                        // e.into()
+                        (error_handler)(e, &req_clone)
+                    } else {
+                        e.into()
+                    };
+
+                    Err(e)
+                })
+        }
+        .boxed_local()
+    }
+}

--- a/src/actix.rs
+++ b/src/actix.rs
@@ -247,6 +247,40 @@ impl<T> DerefMut for QsForm<T> {
     }
 }
 
+// private fields on QsQueryConfig prevent its reuse here, so a new struct
+// is defined
+
+pub struct QsFormConfig {
+    ehandler: Option<Arc<dyn Fn(QsError, &HttpRequest) -> ActixError + Send + Sync>>,
+    qs_config: QsConfig,
+}
+
+impl QsFormConfig {
+    /// Set custom error handler
+    pub fn error_handler<F>(mut self, f: F) -> Self
+    where
+        F: Fn(QsError, &HttpRequest) -> ActixError + Send + Sync + 'static,
+    {
+        self.ehandler = Some(Arc::new(f));
+        self
+    }
+
+    /// Set custom serialization parameters
+    pub fn qs_config(mut self, config: QsConfig) -> Self {
+        self.qs_config = config;
+        self
+    }
+}
+
+impl Default for QsFormConfig {
+    fn default() -> Self {
+        QsFormConfig {
+            qs_config: QsConfig::default(),
+            ehandler: None,
+        }
+    }
+}
+
 // See:
 // - https://github.com/actix/actix-web/blob/master/src/types/form.rs
 // - https://github.com/samscott89/serde_qs/blob/main/src/actix.rs


### PR DESCRIPTION
Adds QsForm Extractor for Actix-web so that web forms can support arrays and other features of serde_qs

Resolves #52 using code provided by [rapodaca](https://github.com/rapodaca)