### PR TITLE
docs.rs: generate docs for axum support as well

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ warp = ["futures", "tracing", "warp-framework"]
 axum = ["axum-framework", "futures"]
 
 [package.metadata.docs.rs]
-features = ["actix4", "warp"]
+features = ["actix4", "warp", "axum"]
 
 [[example]]
 name = "csv_vectors"


### PR DESCRIPTION
`axum` support is missing from docs.rs. This enables it in addition to `actix` and `warp`.