### PR TITLE
Support preserving order of parameters when serializing to a Map.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
           - actix3
           - warp
           - axum
+          - indexmap
 
         # test frameworks for specific MSRVs (where known)
         include:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ thiserror = "1.0"
 tracing = { version = "0.1", optional = true }
 warp-framework = { package = "warp", version = "0.3", default-features = false, optional = true }
 axum-framework = { package = "axum", version = "0.7", default-features = false, optional = true }
+indexmap = { version = "2.2", optional = true, features = ["serde"] }
 
 [dev-dependencies]
 chrono = { version = "0.4", features = ["serde"] }
@@ -40,6 +41,7 @@ actix2 = []
 actix = []
 warp = ["futures", "tracing", "warp-framework"]
 axum = ["axum-framework", "futures"]
+indexmap = ["dep:indexmap"]
 
 [package.metadata.docs.rs]
 features = ["actix4", "warp"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,4 +48,3 @@ features = ["actix4", "warp"]
 
 [[example]]
 name = "csv_vectors"
-test = true

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -43,8 +43,8 @@ use crate::error::*;
 use serde::de;
 use serde::de::IntoDeserializer;
 
+use crate::map::{Entry, IntoIter, Map};
 use std::borrow::Cow;
-use std::collections::btree_map::{BTreeMap, Entry, IntoIter};
 
 /// To override the default serialization parameters, first construct a new
 /// Config.
@@ -202,8 +202,8 @@ pub struct QsDeserializer<'a> {
 
 #[derive(Debug)]
 enum Level<'a> {
-    Nested(BTreeMap<Cow<'a, str>, Level<'a>>),
-    OrderedSeq(BTreeMap<usize, Level<'a>>),
+    Nested(Map<Cow<'a, str>, Level<'a>>),
+    OrderedSeq(Map<usize, Level<'a>>),
     Sequence(Vec<Level<'a>>),
     Flat(Cow<'a, str>),
     Invalid(String),
@@ -211,7 +211,7 @@ enum Level<'a> {
 }
 
 impl<'a> QsDeserializer<'a> {
-    fn with_map(map: BTreeMap<Cow<'a, str>, Level<'a>>) -> Self {
+    fn with_map(map: Map<Cow<'a, str>, Level<'a>>) -> Self {
         QsDeserializer {
             iter: map.into_iter(),
             value: None,

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -356,7 +356,7 @@ impl<'de> de::MapAccess<'de> for QsDeserializer<'de> {
         // we'll prefer to use the field order if it exists
         if let Some(field_order) = &mut self.field_order {
             for (idx, field) in field_order.iter().enumerate() {
-                if let Some((key, value)) = self.map.remove_entry(*field) {
+                if let Some((key, value)) = crate::map::remove_entry(&mut self.map, *field) {
                     self.value = Some(value);
                     *field_order = &field_order[idx + 1..];
                     return seed.deserialize(ParsableStringDeserializer(key)).map(Some);
@@ -368,7 +368,7 @@ impl<'de> de::MapAccess<'de> for QsDeserializer<'de> {
 
         // once we've exhausted the field order, we can
         // just iterate remaining elements in the map
-        if let Some((key, value)) = self.map.pop_first() {
+        if let Some((key, value)) = crate::map::pop_first(&mut self.map) {
             self.value = Some(value);
             let has_bracket = key.contains('[');
             seed.deserialize(ParsableStringDeserializer(key))
@@ -409,7 +409,7 @@ impl<'de> de::EnumAccess<'de> for QsDeserializer<'de> {
     where
         V: de::DeserializeSeed<'de>,
     {
-        if let Some((key, value)) = self.map.pop_first() {
+        if let Some((key, value)) = crate::map::pop_first(&mut self.map) {
             self.value = Some(value);
             Ok((seed.deserialize(ParsableStringDeserializer(key))?, self))
         } else {

--- a/src/de/parse.rs
+++ b/src/de/parse.rs
@@ -46,7 +46,7 @@ impl<'a> Level<'a> {
                 }
             }
         } else if let Level::Uninitialised = *self {
-            let mut map = BTreeMap::default();
+            let mut map = Map::default();
             let _ = map.insert(key, Level::Flat(value));
             *self = Level::Nested(map);
         } else {
@@ -73,7 +73,7 @@ impl<'a> Level<'a> {
             }
         } else if let Level::Uninitialised = *self {
             // To reach here, self is either an OrderedSeq or nothing.
-            let mut map = BTreeMap::default();
+            let mut map = Map::default();
             let _ = map.insert(key, Level::Flat(value));
             *self = Level::OrderedSeq(map);
         } else {
@@ -274,14 +274,14 @@ impl<'a> Parser<'a> {
     /// In some ways the main way to use a `Parser`, this runs the parsing step
     /// and outputs a simple `Deserializer` over the parsed map.
     pub(crate) fn as_deserializer(&mut self) -> Result<QsDeserializer<'a>> {
-        let map = BTreeMap::default();
+        let map = Map::new();
         let mut root = Level::Nested(map);
 
         // Parses all top level nodes into the `root` map.
         while self.parse(&mut root)? {}
         let iter = match root {
             Level::Nested(map) => map.into_iter(),
-            _ => BTreeMap::default().into_iter(),
+            _ => Map::new().into_iter(),
         };
         Ok(QsDeserializer { iter, value: None })
     }
@@ -450,7 +450,7 @@ impl<'a> Parser<'a> {
                         // The key continues to another level of nested.
                         // Add a new unitialised level for this node and continue.
                         if let Level::Uninitialised = *node {
-                            *node = Level::Nested(BTreeMap::default());
+                            *node = Level::Nested(Map::default());
                         }
                         if let Level::Nested(ref mut map) = *node {
                             // By parsing we drop down another level
@@ -527,7 +527,7 @@ impl<'a> Parser<'a> {
                         // The key continues to another level of nested.
                         // Add a new unitialised level for this node and continue.
                         if let Level::Uninitialised = *node {
-                            *node = Level::OrderedSeq(BTreeMap::default());
+                            *node = Level::OrderedSeq(Map::default());
                         }
                         if let Level::OrderedSeq(ref mut map) = *node {
                             // By parsing we drop down another level

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,8 +227,22 @@ pub mod warp;
 
 #[cfg(feature = "indexmap")]
 mod indexmap {
-    pub use indexmap::map::{Entry, IntoIter};
+    use std::borrow::Borrow;
+
+    pub use indexmap::map::Entry;
     pub use indexmap::IndexMap as Map;
+
+    pub fn remove_entry<K, V, Q>(map: &mut Map<K, V>, key: &Q) -> Option<(K, V)>
+    where
+        K: Borrow<Q> + std::hash::Hash + Eq,
+        Q: ?Sized + std::hash::Hash + Eq,
+    {
+        map.shift_remove_entry(key)
+    }
+
+    pub fn pop_first<K, V>(map: &mut Map<K, V>) -> Option<(K, V)> {
+        map.shift_remove_index(0)
+    }
 }
 
 #[cfg(feature = "indexmap")]
@@ -236,8 +250,21 @@ pub(crate) use indexmap as map;
 
 #[cfg(not(feature = "indexmap"))]
 mod btree_map {
-    pub use std::collections::btree_map::{Entry, IntoIter};
+    use std::borrow::Borrow;
+    pub use std::collections::btree_map::Entry;
     pub use std::collections::BTreeMap as Map;
+
+    pub fn remove_entry<K, V, Q>(map: &mut Map<K, V>, key: &Q) -> Option<(K, V)>
+    where
+        K: Borrow<Q> + Ord,
+        Q: ?Sized + Ord,
+    {
+        map.remove_entry(key)
+    }
+
+    pub fn pop_first<K: Ord, V>(map: &mut Map<K, V>) -> Option<(K, V)> {
+        map.pop_first()
+    }
 }
 
 #[cfg(not(feature = "indexmap"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,7 +246,7 @@ mod indexmap {
 }
 
 #[cfg(feature = "indexmap")]
-pub(crate) use indexmap as map;
+pub(crate) use crate::indexmap as map;
 
 #[cfg(not(feature = "indexmap"))]
 mod btree_map {
@@ -268,4 +268,4 @@ mod btree_map {
 }
 
 #[cfg(not(feature = "indexmap"))]
-pub(crate) use btree_map as map;
+pub(crate) use crate::btree_map as map;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,3 +224,21 @@ pub mod axum;
 
 #[cfg(feature = "warp")]
 pub mod warp;
+
+#[cfg(feature = "indexmap")]
+mod indexmap {
+    pub use indexmap::map::{Entry, IntoIter};
+    pub use indexmap::IndexMap as Map;
+}
+
+#[cfg(feature = "indexmap")]
+pub(crate) use indexmap as map;
+
+#[cfg(not(feature = "indexmap"))]
+mod btree_map {
+    pub use std::collections::btree_map::{Entry, IntoIter};
+    pub use std::collections::BTreeMap as Map;
+}
+
+#[cfg(not(feature = "indexmap"))]
+pub(crate) use btree_map as map;

--- a/tests/test_deserialize.rs
+++ b/tests/test_deserialize.rs
@@ -683,6 +683,45 @@ fn deserialize_map_with_unit_enum_keys() {
     assert_eq!(test.point[&Operator::Lt], 321);
 }
 
+#[cfg(feature = "indexmap")]
+#[test]
+fn deserialize_map_with_unit_enum_keys_preserves_order() {
+    use indexmap::IndexMap;
+
+    #[derive(Deserialize, Eq, PartialEq, Hash, Debug)]
+    enum Key {
+        Name,
+        Age,
+    }
+
+    #[derive(Deserialize, Eq, PartialEq, Hash, Debug)]
+    enum Order {
+        Asc,
+        Desc,
+    }
+
+    #[derive(Deserialize)]
+    struct Sort {
+        sort: IndexMap<Key, Order>,
+    }
+
+    let test1: Sort = serde_qs::from_str("sort[Name]=Asc&sort[Age]=Desc").unwrap();
+    let values1 = test1.sort.into_iter().collect::<Vec<_>>();
+
+    assert_eq!(
+        values1,
+        vec![(Key::Name, Order::Asc), (Key::Age, Order::Desc)]
+    );
+
+    let test2: Sort = serde_qs::from_str("sort[Age]=Desc&sort[Name]=Asc").unwrap();
+    let values2 = test2.sort.into_iter().collect::<Vec<_>>();
+
+    assert_eq!(
+        values2,
+        vec![(Key::Age, Order::Desc), (Key::Name, Order::Asc)]
+    );
+}
+
 #[test]
 fn deserialize_map_with_int_keys() {
     #[derive(Debug, Deserialize)]


### PR DESCRIPTION
Dear samscott89,
Please consider this pull request.

# What it does?

This PR adds support for deserializing queries into ordered maps, such as `IndexMap`.

# How?

It adds a new feature, called `indexmap`, that replaces the `BTreeMap` used internall by `serd_qs` with an `IndexMap`.

# Why?

Sometimes the order of the keys in the query is important. On example is sorting. What if you want to sort by one field, and then by other?

# Was it tested?

There's a new test. It parses a two queries into a map. The queries are almost the same, but the order of the keys is swapped.