### PR TITLE
Serialize vectors without indices

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,7 +217,9 @@ pub use de::{from_bytes, from_str};
 pub use de::{Config, QsDeserializer as Deserializer};
 pub use error::Error;
 #[doc(inline)]
-pub use ser::{to_string, to_writer, Serializer};
+pub use ser::Config as SerializerConfig;
+#[doc(inline)]
+pub use ser::{to_string, to_string_config, to_writer, Serializer};
 
 #[cfg(feature = "axum")]
 pub mod axum;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -102,6 +102,35 @@ pub fn to_string<T: ser::Serialize>(input: &T) -> Result<String> {
     to_string_config(input, Config::default())
 }
 
+/// Serializes a value into a querystring with a custom configuration.
+///
+/// ```
+/// # #[macro_use]
+/// # extern crate serde_derive;
+/// # extern crate serde_qs;
+/// #[derive(Deserialize, Serialize)]
+/// struct Query {
+///     name: String,
+///     age: u8,
+///     occupation: String,
+///     degrees: Vec<String>,
+/// }
+///
+/// # fn main(){
+/// let q =  Query {
+///     name: "Alice".to_owned(),
+///     age: 24,
+///     occupation: "Student".to_owned(),
+///     degrees: vec!["BSc".to_owned(), "MSc".to_owned()],
+/// };
+///
+/// let config = serde_qs::SerializerConfig { use_indices: false };
+///
+/// assert_eq!(
+///     serde_qs::to_string_config(&q, config).unwrap(),
+///     "name=Alice&age=24&occupation=Student&degrees[]=BSc&degrees[]=MSc");
+/// # }
+/// ```
 pub fn to_string_config<T: ser::Serialize>(input: &T, config: Config) -> Result<String> {
     let mut buffer = Vec::new();
     input.serialize(&mut Serializer::with_config(&mut buffer, config))?;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -99,9 +99,7 @@ impl Default for Config {
 /// # }
 /// ```
 pub fn to_string<T: ser::Serialize>(input: &T) -> Result<String> {
-    let mut buffer = Vec::new();
-    input.serialize(&mut Serializer::new(&mut buffer))?;
-    String::from_utf8(buffer).map_err(Error::from)
+    to_string_config(input, Config::default())
 }
 
 pub fn to_string_config<T: ser::Serialize>(input: &T, config: Config) -> Result<String> {

--- a/tests/test_serialize.rs
+++ b/tests/test_serialize.rs
@@ -43,6 +43,32 @@ fn serialize_struct() {
 }
 
 #[test]
+fn serialize_struct_without_indices() {
+    let params = QueryParams {
+        id: 42,
+        name: "Acme".to_string(),
+        phone: 12345,
+        address: Address {
+            city: "Carrot City".to_string(),
+            street: "Special-Street* No. 11".to_string(),
+            postcode: "12345".to_string(),
+        },
+        user_ids: vec![1, 2, 3, 4],
+    };
+
+    let config = qs::SerializerConfig { use_indices: false };
+
+    assert_eq!(
+        qs::to_string_config(&params, config).unwrap(),
+        "\
+         id=42&name=Acme&phone=12345&address[city]=Carrot+City&\
+         address[street]=Special-Street*+No.+11&\
+         address[postcode]=12345&user_ids[]=1&user_ids[]=2&\
+         user_ids[]=3&user_ids[]=4"
+    );
+}
+
+#[test]
 fn serialize_option() {
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
     struct Query {


### PR DESCRIPTION
This is a proof of concept to serialize a vector without indices in the query string `user_ids[]=100&user_ids[]=101`. The default is using indices `user_ids[0]=100&user_ids[1]=101`. The structure without the indices is used by ie. the OpenAI API.

I added a new method `to_string_config(input, config)` to be able to serialize with a custom configuration. The existing method `to_string(input)` will work the same as before and will use the default config (using indices).

The new config currently only has the field `use_indices` of type boolean - but can be expanded later if needed.

I'm not really a fan of using two different methods, do you have any suggestion on how you would like this to work? @samscott89
As there is no standard for this type of serialization - if you do not want to support this, feel free to close it. Thanks.

```rust 
let params = QueryParams {
    id: 42,
    user_ids: vec![1, 2, 3, 4],
};

let config = SerializerConfig { use_indices: false };

assert_eq!(
    serde_qs::to_string_config(&params, config).unwrap(),
    "\
    id=42&user_ids[]=1&user_ids[]=2&\
    user_ids[]=3&user_ids[]=4"
);
```
