### PR TITLE
Add array deserialize support for duplicate keys (without square brackets)

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -652,6 +652,20 @@ impl<'de> de::Deserializer<'de> for LevelDeserializer<'de> {
         }
     }
 
+    /// If we are expected to deserialize into a sequence, and we have only detected
+    /// a single key=value.
+    fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: de::Visitor<'de>,
+    {
+        match self.0 {
+            // Convert a nominal value into a sequence, since we attempted to deserialize into
+            // a sequence, and only detected one entry.
+            Level::Flat(_) => visitor.visit_seq(LevelSeq(vec![self.0].into_iter())),
+            _ => self.deserialize_any(visitor),
+        }
+    }
+
     deserialize_primitive!(bool, deserialize_bool, visit_bool);
     deserialize_primitive!(i8, deserialize_i8, visit_i8);
     deserialize_primitive!(i16, deserialize_i16, visit_i16);
@@ -677,7 +691,7 @@ impl<'de> de::Deserializer<'de> for LevelDeserializer<'de> {
         identifier
         tuple
         ignored_any
-        seq
+        // seq
         // map
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,16 @@
 //! However, after the top level you should find all supported types can be
 //! de/serialized.
 //!
-//! Note that integer keys are reserved for array indices. That is, a string of
-//! the form `a[0]=1&a[1]=3` will deserialize to the ordered sequence `a =
-//! [1,3]`.
+//! ### Arrays
+//!
+//! Sequences of keys can be represented in the following formats:
+//! - Integer indice: `a[0]=X&a[1]=Y` => `a = ['X', 'Y']`
+//! - Empty square bracket: `a[]=X&a[]=Y` => `a = ['X', 'Y']`
+//! - Duplicate keys: `a=X&a=Y` => `a = ['X', 'Y']`
+//!
+//! Note that integer keys are reserved for array indices.
+//! Therefore, it will not be parsed as a nested map, and will be deserialized
+//! to an ordered sequence.
 //!
 //! ## Usage
 //!

--- a/tests/test_deserialize.rs
+++ b/tests/test_deserialize.rs
@@ -93,13 +93,24 @@ fn deserialize_struct() {
             .unwrap();
         assert_eq!(rec_params, params);
 
-        // unindexed arrays
+        // unindexed arrays with square brackets
         let rec_params: QueryParams = config
             .deserialize_str(
                 "\
                  name=Acme&id=42&phone=12345&address[postcode]=12345&\
                  address[city]=Carrot+City&user_ids[]=1&user_ids[]=2&\
                  user_ids[]=3&user_ids[]=4",
+            )
+            .unwrap();
+        assert_eq!(rec_params, params);
+
+        // unindexed arrays without square brackets
+        let rec_params: QueryParams = config
+            .deserialize_str(
+                "\
+                 name=Acme&id=42&phone=12345&address[postcode]=12345&\
+                 address[city]=Carrot+City&user_ids=1&user_ids=2&\
+                 user_ids=3&user_ids=4",
             )
             .unwrap();
         assert_eq!(rec_params, params);

--- a/tests/test_deserialize.rs
+++ b/tests/test_deserialize.rs
@@ -196,6 +196,17 @@ fn qs_test_simple() {
 }
 
 #[test]
+fn duplicate_keys() {
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct Query {
+        key: i64,
+    }
+
+    let params: Result<Query, _> = qs::from_str("key=1&key=2");
+    assert!(params.is_err());
+}
+
+#[test]
 fn no_panic_on_parse_error() {
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
     struct Query {

--- a/tests/test_deserialize.rs
+++ b/tests/test_deserialize.rs
@@ -218,6 +218,22 @@ fn duplicate_keys() {
 }
 
 #[test]
+fn single_bare_key_as_sequence() {
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct Query {
+        key: Vec<i64>,
+    }
+
+    let params: Result<Query, _> = qs::from_str("key=1");
+    assert!(
+        params.is_ok(),
+        "expect to deserialize correctly: {:?}",
+        params
+    );
+    assert_eq!(params.unwrap(), Query { key: vec![1] });
+}
+
+#[test]
 fn no_panic_on_parse_error() {
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
     struct Query {


### PR DESCRIPTION
This PR expands support to handle duplicate keys without square brackets to be parsed as an unordered sequence.

Given the following query params: `id=abc&id=def`

```rust
#[derive(Debug, Deserialize)]
struct Query {
    id: Vec<String>,
}

let query = "id=abc&id=def";
let result: Result<Query, _> = qs::from_str(query);
assert!(result.is_ok());
assert_eq!(result.unwrap(), Query { id: vec!["abc", "def"] });
``` 

This PR closes #35.

Given the discussion and prior position taken to not accept this functionality, I am prepared that this may not be accepted. I would like input from the community for alternative crates that may be a better fit. In general, I am looking a complete parsing solution for typical use-cases encountered from OpenAPI specifications for my server-side query parameter handling.