### PR TITLE
chore: release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.13.1](https://github.com/samscott89/serde_qs/compare/v0.13.0...v0.13.1) - 2025-03-04
+## [0.14.0](https://github.com/samscott89/serde_qs/compare/v0.13.0...v0.14.0) - 2025-03-04
 
 ### Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.13.1](https://github.com/samscott89/serde_qs/compare/v0.13.0...v0.13.1) - 2025-03-04
+
+### Other
+
+- Add release plz CI ([#125](https://github.com/samscott89/serde_qs/pull/125))
+- Update CI config ([#124](https://github.com/samscott89/serde_qs/pull/124))
+- update axum to v0.8 ([#118](https://github.com/samscott89/serde_qs/pull/118))
+- :multiple_bound_locations ([#103](https://github.com/samscott89/serde_qs/pull/103))
+- Add axum::OptionalQsQuery ([#102](https://github.com/samscott89/serde_qs/pull/102))
+- generate docs for axum support as well ([#100](https://github.com/samscott89/serde_qs/pull/100))
+- Update README.md
+
 ## Version 0.13.0
 
 - Bump `axum` support to 0.7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 name = "serde_qs"
 repository = "https://github.com/samscott89/serde_qs"
 readme = "README.md"
-version = "0.13.0"
+version = "0.13.1"
 rust-version = "1.63"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 name = "serde_qs"
 repository = "https://github.com/samscott89/serde_qs"
 readme = "README.md"
-version = "0.13.1"
+version = "0.14.0"
 rust-version = "1.63"
 
 [dependencies]


### PR DESCRIPTION


## 🤖 New release

* `serde_qs`: 0.13.0 -> 0.14.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.0](https://github.com/samscott89/serde_qs/compare/v0.13.0...v0.14.0) - 2025-03-04

### Other

- Add release plz CI ([#125](https://github.com/samscott89/serde_qs/pull/125))
- Update CI config ([#124](https://github.com/samscott89/serde_qs/pull/124))
- update axum to v0.8 ([#118](https://github.com/samscott89/serde_qs/pull/118))
- :multiple_bound_locations ([#103](https://github.com/samscott89/serde_qs/pull/103))
- Add axum::OptionalQsQuery ([#102](https://github.com/samscott89/serde_qs/pull/102))
- generate docs for axum support as well ([#100](https://github.com/samscott89/serde_qs/pull/100))
- Update README.md
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).