### PR TITLE
reorder struct fields to avoid serde buffering

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -44,7 +44,7 @@ use serde::de;
 use serde::de::IntoDeserializer;
 
 use std::borrow::Cow;
-use std::collections::btree_map::{BTreeMap, Entry, IntoIter};
+use std::collections::btree_map::{BTreeMap, Entry};
 
 /// To override the default serialization parameters, first construct a new
 /// Config.
@@ -196,8 +196,9 @@ pub fn from_str<'de, T: de::Deserialize<'de>>(input: &'de str) -> Result<T> {
 ///
 /// Supported top-level outputs are structs and maps.
 pub struct QsDeserializer<'a> {
-    iter: IntoIter<Cow<'a, str>, Level<'a>>,
+    map: BTreeMap<Cow<'a, str>, Level<'a>>,
     value: Option<Level<'a>>,
+    field_order: Option<&'static [&'static str]>,
 }
 
 #[derive(Debug)]
@@ -213,8 +214,9 @@ enum Level<'a> {
 impl<'a> QsDeserializer<'a> {
     fn with_map(map: BTreeMap<Cow<'a, str>, Level<'a>>) -> Self {
         QsDeserializer {
-            iter: map.into_iter(),
+            map,
             value: None,
+            field_order: None,
         }
     }
 
@@ -231,11 +233,11 @@ impl<'a> QsDeserializer<'a> {
 impl<'de> de::Deserializer<'de> for QsDeserializer<'de> {
     type Error = Error;
 
-    fn deserialize_any<V>(mut self, visitor: V) -> Result<V::Value>
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
     {
-        if self.iter.next().is_none() {
+        if self.map.is_empty() {
             return visitor.visit_unit();
         }
 
@@ -250,7 +252,7 @@ impl<'de> de::Deserializer<'de> for QsDeserializer<'de> {
     }
 
     fn deserialize_struct<V>(
-        self,
+        mut self,
         _name: &'static str,
         _fields: &'static [&'static str],
         visitor: V,
@@ -258,6 +260,7 @@ impl<'de> de::Deserializer<'de> for QsDeserializer<'de> {
     where
         V: de::Visitor<'de>,
     {
+        self.field_order = Some(_fields);
         self.deserialize_map(visitor)
     }
 
@@ -347,7 +350,19 @@ impl<'de> de::MapAccess<'de> for QsDeserializer<'de> {
     where
         K: de::DeserializeSeed<'de>,
     {
-        if let Some((key, value)) = self.iter.next() {
+        if let Some(field_order) = &mut self.field_order {
+            for (idx, field) in field_order.iter().enumerate() {
+                if let Some((key, value)) = self.map.remove_entry(*field) {
+                    self.value = Some(value);
+                    *field_order = &field_order[idx + 1..];
+                    return seed.deserialize(ParsableStringDeserializer(key)).map(Some);
+                }
+            }
+
+            self.field_order = None;
+        }
+
+        if let Some((key, value)) = self.map.pop_first() {
             self.value = Some(value);
             let has_bracket = key.contains('[');
             seed.deserialize(ParsableStringDeserializer(key))
@@ -388,7 +403,7 @@ impl<'de> de::EnumAccess<'de> for QsDeserializer<'de> {
     where
         V: de::DeserializeSeed<'de>,
     {
-        if let Some((key, value)) = self.iter.next() {
+        if let Some((key, value)) = self.map.pop_first() {
             self.value = Some(value);
             Ok((seed.deserialize(ParsableStringDeserializer(key))?, self))
         } else {
@@ -576,6 +591,17 @@ impl<'de> de::Deserializer<'de> for LevelDeserializer<'de> {
         }
     }
 
+    fn deserialize_struct<V>(
+        self,
+        name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> std::result::Result<V::Value, Self::Error>
+    where
+        V: de::Visitor<'de> {
+        self.into_deserializer()?.deserialize_struct(name, fields, visitor)
+    }
+
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
@@ -673,7 +699,6 @@ impl<'de> de::Deserializer<'de> for LevelDeserializer<'de> {
         unit_struct
         // newtype_struct
         tuple_struct
-        struct
         identifier
         tuple
         ignored_any

--- a/src/de/parse.rs
+++ b/src/de/parse.rs
@@ -283,7 +283,11 @@ impl<'a> Parser<'a> {
             Level::Nested(map) => map,
             _ => BTreeMap::default(),
         };
-        Ok(QsDeserializer { map, value: None, field_order: None })
+        Ok(QsDeserializer {
+            map,
+            value: None,
+            field_order: None,
+        })
     }
 
     /// This is the top level parsing function. It checks the first character to

--- a/src/de/parse.rs
+++ b/src/de/parse.rs
@@ -279,11 +279,11 @@ impl<'a> Parser<'a> {
 
         // Parses all top level nodes into the `root` map.
         while self.parse(&mut root)? {}
-        let iter = match root {
-            Level::Nested(map) => map.into_iter(),
-            _ => BTreeMap::default().into_iter(),
+        let map = match root {
+            Level::Nested(map) => map,
+            _ => BTreeMap::default(),
         };
-        Ok(QsDeserializer { iter, value: None })
+        Ok(QsDeserializer { map, value: None, field_order: None })
     }
 
     /// This is the top level parsing function. It checks the first character to

--- a/tests/test_deserialize.rs
+++ b/tests/test_deserialize.rs
@@ -348,6 +348,50 @@ fn deserialize_enum_adjacently() {
 }
 
 #[test]
+fn deserialize_enum_adjacently_out_of_order() {
+    #[derive(Deserialize, Debug, PartialEq)]
+    #[serde(tag = "Z", content = "A")]
+    enum E {
+        B(bool),
+        S(String),
+    }
+
+    #[derive(Deserialize, Debug, PartialEq)]
+    #[serde(tag = "Z", content = "A")]
+    enum V {
+        V1 { x: u8, y: u16 },
+        V2(String),
+    }
+
+    #[derive(Deserialize, Debug, PartialEq)]
+    struct Query {
+        e: E,
+        v: Option<V>,
+    }
+
+    let params = "e[Z]=B&e[A]=true&v[Z]=V1&v[A][x]=12&v[A][y]=300";
+    let rec_params: Query = qs::from_str(params).unwrap();
+    assert_eq!(
+        rec_params,
+        Query {
+            e: E::B(true),
+            v: Some(V::V1 { x: 12, y: 300 }),
+        }
+    );
+
+    let params = "e[Z]=S&e[A]=other";
+    let rec_params: Query = qs::from_str(params).unwrap();
+    assert_eq!(
+        rec_params,
+        Query {
+            e: E::S("other".to_string()),
+            v: None,
+        }
+    );
+}
+
+
+#[test]
 fn deserialize_enum() {
     #[derive(Deserialize, Debug, PartialEq)]
     struct NewU8(u8);

--- a/tests/test_deserialize.rs
+++ b/tests/test_deserialize.rs
@@ -390,7 +390,6 @@ fn deserialize_enum_adjacently_out_of_order() {
     );
 }
 
-
 #[test]
 fn deserialize_enum() {
     #[derive(Deserialize, Debug, PartialEq)]


### PR DESCRIPTION
Fixes #127 

This pr respects serde's struct deserialize ordering when deserializing struct values which has the effect of mitigating buffering in some cases.