### PR TITLE
chore: release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.14.1](https://github.com/samscott89/serde_qs/compare/v0.14.0...v0.14.1) - 2025-04-22
+## [0.15.0](https://github.com/samscott89/serde_qs/compare/v0.14.0...v0.15.0) - 2025-04-22
 
 ### Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.14.1](https://github.com/samscott89/serde_qs/compare/v0.14.0...v0.14.1) - 2025-04-22
+
+### Other
+
+- Support preserving order of parameters when serializing to a Map. ([#106](https://github.com/samscott89/serde_qs/pull/106))
+- Fix clippy. ([#129](https://github.com/samscott89/serde_qs/pull/129))
+- reorder struct fields to avoid serde buffering ([#128](https://github.com/samscott89/serde_qs/pull/128))
+
 ## [0.14.0](https://github.com/samscott89/serde_qs/compare/v0.13.0...v0.14.0) - 2025-03-04
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 name = "serde_qs"
 repository = "https://github.com/samscott89/serde_qs"
 readme = "README.md"
-version = "0.14.1"
+version = "0.15.0"
 rust-version = "1.66"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 name = "serde_qs"
 repository = "https://github.com/samscott89/serde_qs"
 readme = "README.md"
-version = "0.14.0"
+version = "0.14.1"
 rust-version = "1.66"
 
 [dependencies]


### PR DESCRIPTION



## 🤖 New release

* `serde_qs`: 0.14.0 -> 0.14.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.1](https://github.com/samscott89/serde_qs/compare/v0.14.0...v0.14.1) - 2025-04-22

### Other

- Support preserving order of parameters when serializing to a Map. ([#106](https://github.com/samscott89/serde_qs/pull/106))
- Fix clippy. ([#129](https://github.com/samscott89/serde_qs/pull/129))
- reorder struct fields to avoid serde buffering ([#128](https://github.com/samscott89/serde_qs/pull/128))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).