### PR TITLE
chore: release v1.0.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.0.0-rc.1](https://github.com/samscott89/serde_qs/compare/v1.0.0-rc.0...v1.0.0-rc.1) - 2025-05-26
+
+### Other
+
+- Fix maps with integer keys. ([#138](https://github.com/samscott89/serde_qs/pull/138))
+- Support explicit serialization formatting for arrays. ([#137](https://github.com/samscott89/serde_qs/pull/137))
+- v1 changelog (and more tests) ([#135](https://github.com/samscott89/serde_qs/pull/135))
+
 ## [1.0.0-rc.0](https://github.com/samscott89/serde_qs/compare/v0.15.0...v1.0.0-rc.0) - 2025-05-26
 
 This release constitutes an full, incremental rewrite of v0.15 (the core of which was written about [8 years ago](https://github.com/samscott89/serde_qs/commit/6e71ba43eb6bd62f2b567224e387333016bd3a5c#diff-a9463680bdf3fa7278b52b437bfbe9072e20023a015621ed23bcb589f6ccd4b5)).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 name = "serde_qs"
 repository = "https://github.com/samscott89/serde_qs"
 readme = "README.md"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 rust-version = "1.68"
 
 [dependencies]


### PR DESCRIPTION



## 🤖 New release

* `serde_qs`: 1.0.0-rc.0 -> 1.0.0-rc.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.0-rc.1](https://github.com/samscott89/serde_qs/compare/v1.0.0-rc.0...v1.0.0-rc.1) - 2025-05-26

### Other

- Fix maps with integer keys. ([#138](https://github.com/samscott89/serde_qs/pull/138))
- Support explicit serialization formatting for arrays. ([#137](https://github.com/samscott89/serde_qs/pull/137))
- v1 changelog (and more tests) ([#135](https://github.com/samscott89/serde_qs/pull/135))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).