### PR TITLE
chore: release v1.0.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.0-rc.2](https://github.com/samscott89/serde_qs/compare/v1.0.0-rc.1...v1.0.0-rc.2) - 2025-05-27
+
+### Other
+
+- A little cleanup in web utils ([#140](https://github.com/samscott89/serde_qs/pull/140))
+- Sam/more tests ([#139](https://github.com/samscott89/serde_qs/pull/139))
+
 ## [1.0.0-rc.1](https://github.com/samscott89/serde_qs/compare/v1.0.0-rc.0...v1.0.0-rc.1) - 2025-05-26
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### Other
 
-- A little cleanup in web utils ([#140](https://github.com/samscott89/serde_qs/pull/140))
-- Sam/more tests ([#139](https://github.com/samscott89/serde_qs/pull/139))
+- Cleanup of web utils remove redundant `OptionalQsQuery` (since `Option<T>` now works)
+  and add `QsForm` ([#140](https://github.com/samscott89/serde_qs/pull/140))
+- More tests / minor change to field encoding ([#139](https://github.com/samscott89/serde_qs/pull/139))
 
 ## [1.0.0-rc.1](https://github.com/samscott89/serde_qs/compare/v1.0.0-rc.0...v1.0.0-rc.1) - 2025-05-26
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 name = "serde_qs"
 repository = "https://github.com/samscott89/serde_qs"
 readme = "README.md"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 rust-version = "1.68"
 
 [dependencies]


### PR DESCRIPTION



## 🤖 New release

* `serde_qs`: 1.0.0-rc.1 -> 1.0.0-rc.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.0-rc.2](https://github.com/samscott89/serde_qs/compare/v1.0.0-rc.1...v1.0.0-rc.2) - 2025-05-27

### Other

- A little cleanup in web utils ([#140](https://github.com/samscott89/serde_qs/pull/140))
- Sam/more tests ([#139](https://github.com/samscott89/serde_qs/pull/139))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).