### PR TITLE
chore: release v1.0.0-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.0-rc.3](https://github.com/samscott89/serde_qs/compare/v1.0.0-rc.2...v1.0.0-rc.3) - 2025-05-27
+
+### Other
+
+- Error when hitting serialization max depth ([#144](https://github.com/samscott89/serde_qs/pull/144))
+- Deserialize empty value as bool=true ([#142](https://github.com/samscott89/serde_qs/pull/142))
+
 ## [1.0.0-rc.2](https://github.com/samscott89/serde_qs/compare/v1.0.0-rc.1...v1.0.0-rc.2) - 2025-05-27
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 name = "serde_qs"
 repository = "https://github.com/samscott89/serde_qs"
 readme = "README.md"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 rust-version = "1.68"
 
 [dependencies]


### PR DESCRIPTION



## 🤖 New release

* `serde_qs`: 1.0.0-rc.2 -> 1.0.0-rc.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.0-rc.3](https://github.com/samscott89/serde_qs/compare/v1.0.0-rc.2...v1.0.0-rc.3) - 2025-05-27

### Other

- Error when hitting serialization max depth ([#144](https://github.com/samscott89/serde_qs/pull/144))
- Deserialize empty value as bool=true ([#142](https://github.com/samscott89/serde_qs/pull/142))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).