### PR TITLE
chore: release v1.0.0-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.0.0-rc.4](https://github.com/samscott89/serde_qs/compare/v1.0.0-rc.3...v1.0.0-rc.4) - 2025-12-14
+
+### Other
+
+- Bump warp ([#156](https://github.com/samscott89/serde_qs/pull/156))
+- Update deserialization logic + add principles. ([#147](https://github.com/samscott89/serde_qs/pull/147))
+- Bump MSRV + add profiling examples ([#154](https://github.com/samscott89/serde_qs/pull/154))
+
 ## [1.0.0-rc.3](https://github.com/samscott89/serde_qs/compare/v1.0.0-rc.2...v1.0.0-rc.3) - 2025-05-27
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 name = "serde_qs"
 repository = "https://github.com/samscott89/serde_qs"
 readme = "README.md"
-version = "1.0.0-rc.3"
+version = "1.0.0-rc.4"
 rust-version = "1.82"
 
 [dependencies]


### PR DESCRIPTION



## 🤖 New release

* `serde_qs`: 1.0.0-rc.3 -> 1.0.0-rc.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.0-rc.4](https://github.com/samscott89/serde_qs/compare/v1.0.0-rc.3...v1.0.0-rc.4) - 2025-12-14

### Other

- Bump warp ([#156](https://github.com/samscott89/serde_qs/pull/156))
- Update deserialization logic + add principles. ([#147](https://github.com/samscott89/serde_qs/pull/147))
- Bump MSRV + add profiling examples ([#154](https://github.com/samscott89/serde_qs/pull/154))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).