### PR TITLE
chore: fix typos and improve clarity in documentation comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ This release constitutes an full, incremental rewrite of v0.15 (the core of whic
 
 The rewrite:
 - addresses numerous existing bugs and feature requests
-- expands support for many more tyype
+- expands support for many more types
 - ensures most types roundtrip (ser -> de) correctly, with an extensive test suite to check
 - implements numerous performance optimizations, resulting in ~3x speedup and times generally in the sub-microsecond range.
 - simplifies a ton of the internal code, removing unnecessary de/serialization abstractions

--- a/src/axum.rs
+++ b/src/axum.rs
@@ -16,7 +16,7 @@ use axum::{
     BoxError, Error,
 };
 
-/// Extract typed information from from the request's query.
+/// Extract typed information from the request's query.
 ///
 /// ## Example
 ///
@@ -73,7 +73,7 @@ where
     }
 }
 
-/// Extract typed information from from the request's formdata.
+/// Extract typed information from the request's formdata.
 ///
 /// For a `GET` request, this will extract the query string as form data.
 /// Otherwise, it will extract the body of the request as form data.

--- a/src/de.rs
+++ b/src/de.rs
@@ -44,8 +44,8 @@
 //!    we'll try to parse the string into a `u8`.
 //!
 //! 2. However, we'll draw the line at converting types that are fundamentally incompatible.
-//!    If we cannot represent the type try coerce the value we have into the value
-//!    they expect, and if we cant do that forward to `deserialize_any``
+//!    If we cannot represent the type and coerce the value we have into the value
+//!    they expect, and if we can't do that, forward to `deserialize_any`
 //!
 //!    For example, if they call `deserialize_string` and we have a `Map`, we won't
 //!    try to convert the map into a string. Instead, we'll forward to

--- a/src/de/parse.rs
+++ b/src/de/parse.rs
@@ -114,7 +114,7 @@ impl fmt::Debug for ParsedValue<'_> {
             ParsedValue::String(s) => write!(f, "String({})", String::from_utf8_lossy(s)),
             ParsedValue::Null => write!(f, "Null"),
             ParsedValue::NoValue => write!(f, "NoValue"),
-            ParsedValue::Uninitialized => write!(f, "Unintialized"),
+            ParsedValue::Uninitialized => write!(f, "Uninitialized"),
         }
     }
 }
@@ -504,7 +504,7 @@ impl<'qs> Parser<'qs> {
                 return Ok(());
             }
             ParsedValue::String(_) => {
-                // we'll support mutliple values for the same key
+                // we'll support multiple values for the same key
                 // by converting the existing value into a sequence
                 // and pushing the new value into it
                 // later we'll handle this case by taking the last value of

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,7 +25,7 @@ pub enum Error {
     #[error("unsupported type for serialization")]
     Unsupported,
 
-    /// Error proessing UTF-8 for a `String`
+    /// Error processing UTF-8 for a `String`
     #[error(transparent)]
     FromUtf8(#[from] string::FromUtf8Error),
 

--- a/src/warp.rs
+++ b/src/warp.rs
@@ -11,7 +11,7 @@ use warp::{http::StatusCode, reject::Reject, Filter, Rejection, Reply};
 
 impl Reject for error::Error {}
 
-/// Extract typed information from from the request's query.
+/// Extract typed information from the request's query.
 ///
 /// ## Example
 ///


### PR DESCRIPTION
This commit fixes several typos and grammatical issues in the documentation comments across the codebase, including correcting "Unintialized" to "Uninitialized", fixing "proessing" to "processing", and improving sentence structure for better clarity. 
