### PR TITLE
chore: release v1.0.0-rc.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.0-rc.5](https://github.com/samscott89/serde_qs/compare/v1.0.0-rc.4...v1.0.0-rc.5) - 2026-01-09
+
+### Other
+
+- fix typos and improve clarity in documentation comments ([#157](https://github.com/samscott89/serde_qs/pull/157))
+
 ## [1.0.0-rc.4](https://github.com/samscott89/serde_qs/compare/v1.0.0-rc.3...v1.0.0-rc.4) - 2025-12-14
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 name = "serde_qs"
 repository = "https://github.com/samscott89/serde_qs"
 readme = "README.md"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 rust-version = "1.82"
 
 [dependencies]


### PR DESCRIPTION



## 🤖 New release

* `serde_qs`: 1.0.0-rc.4 -> 1.0.0-rc.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.0-rc.5](https://github.com/samscott89/serde_qs/compare/v1.0.0-rc.4...v1.0.0-rc.5) - 2026-01-09

### Other

- fix typos and improve clarity in documentation comments ([#157](https://github.com/samscott89/serde_qs/pull/157))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).