### PR TITLE
fix: do not strict-validate ignored compound fields

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -750,6 +750,10 @@ impl<'de> de::Deserializer<'de> for QsDeserializer<'de> {
                 Cow::Borrowed(s) => visitor.visit_borrowed_bytes(s),
                 Cow::Owned(s) => visitor.visit_byte_buf(s),
             },
+            // for compound values that are going to be discarded, visit a
+            // unit so we don't fail validation (e.g. strict sequence index
+            // checks) on data the user has chosen to ignore.
+            ParsedValue::Map(_) | ParsedValue::Sequence(_) => visitor.visit_unit(),
             _ => self.deserialize_any(visitor),
         }
     }

--- a/tests/test_regression.rs
+++ b/tests/test_regression.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 #[test]
@@ -15,4 +17,32 @@ fn double_encoding_keys() {
     let encoded = serde_qs::to_string(&human).unwrap();
     print!("{}", encoded);
     assert_eq!(serde_qs::from_str::<Human>(&encoded).unwrap(), human);
+}
+
+#[test]
+fn ignored_compound_fields_do_not_fail_index_check() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Test {
+        example: HashMap<i32, i32>,
+    }
+
+    let decoded: Test = serde_qs::from_str("example[123]=321&unrelated[123]=321").unwrap();
+    assert_eq!(decoded.example.get(&123), Some(&321));
+
+    let decoded: Test = serde_qs::from_str("example[123]=321&unrelated[0][a]=1").unwrap();
+    assert_eq!(decoded.example.get(&123), Some(&321));
+}
+
+#[test]
+fn skipped_compound_fields_do_not_fail_index_check() {
+    #[derive(Debug, Default, Deserialize, PartialEq)]
+    struct Test {
+        example: HashMap<i32, i32>,
+        #[serde(skip)]
+        unrelated: i8,
+    }
+
+    let decoded: Test = serde_qs::from_str("example[123]=321&unrelated[123]=321").unwrap();
+    assert_eq!(decoded.example.get(&123), Some(&321));
+    assert_eq!(decoded.unrelated, 0);
 }


### PR DESCRIPTION
Treat ignored compound values (`ParsedValue::Map` and `ParsedValue::Sequence`) as units in `deserialize_ignored_any` so unknown or `#[serde(skip)]` fields whose query keys look like arrays no longer trigger the strict index check in `OrderedSeq::next_element_seed`.

Closes #167