### PR TITLE
chore: release v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.2](https://github.com/samscott89/serde_qs/compare/v1.1.1...v1.1.2) - 2026-05-15
+
+### Fixed
+
+- do not strict-validate ignored compound fields ([#168](https://github.com/samscott89/serde_qs/pull/168))
+
 ## [1.1.1](https://github.com/samscott89/serde_qs/compare/v1.1.0...v1.1.1) - 2026-04-05
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 name = "serde_qs"
 repository = "https://github.com/samscott89/serde_qs"
 readme = "README.md"
-version = "1.1.1"
+version = "1.1.2"
 rust-version = "1.85"
 
 [dependencies]


### PR DESCRIPTION



## 🤖 New release

* `serde_qs`: 1.1.1 -> 1.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.2](https://github.com/samscott89/serde_qs/compare/v1.1.1...v1.1.2) - 2026-05-15

### Fixed

- do not strict-validate ignored compound fields ([#168](https://github.com/samscott89/serde_qs/pull/168))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).