### PR TITLE
Fix: multiple values including null return parsing error

### DIFF
--- a/src/de/parse.rs
+++ b/src/de/parse.rs
@@ -3,7 +3,7 @@ use std::iter::Iterator;
 use std::slice::Iter;
 use std::{fmt, str};
 
-use crate::error::{Error, Result};
+use crate::error::Result;
 use crate::map::{Entry, Map};
 
 use super::string_parser::StringParsingDeserializer;

--- a/src/de/parse.rs
+++ b/src/de/parse.rs
@@ -511,7 +511,7 @@ impl<'qs> Parser<'qs> {
                 parsed_values.push(value);
                 return Ok(());
             }
-            ParsedValue::String(_) => {
+            ParsedValue::String(_) | ParsedValue::NoValue | ParsedValue::Null => {
                 // we'll support multiple values for the same key
                 // by converting the existing value into a sequence
                 // and pushing the new value into it
@@ -521,12 +521,6 @@ impl<'qs> Parser<'qs> {
                 let mut seq = vec![existing];
                 seq.push(value);
                 *entry = ParsedValue::Sequence(seq);
-            }
-            ParsedValue::NoValue | ParsedValue::Null => {
-                return Err(Error::parse_err(
-                    "Multiple values for the same key".to_string(),
-                    self.index,
-                ));
             }
             ParsedValue::Uninitialized => {
                 // initialize it

--- a/tests/test_deserialize.rs
+++ b/tests/test_deserialize.rs
@@ -1625,3 +1625,55 @@ fn empty_values() {
 
     deserialize_test("a", &Query { a: "".to_string() });
 }
+
+/// Check that multiple values including null / NoValue will not cause an error
+#[test]
+fn empty_values_multi_values_take_last() {
+    #[derive(Deserialize, Debug, PartialEq)]
+    struct Query {
+        a: String,
+    }
+
+    deserialize_test(
+        "a=&a=hello",
+        &Query {
+            a: "hello".to_string(),
+        },
+    );
+
+    deserialize_test(
+        "a&a=hello",
+        &Query {
+            a: "hello".to_string(),
+        },
+    );
+
+    deserialize_test("a=hello&a=", &Query { a: "".to_string() });
+    deserialize_test("a=hello&a", &Query { a: "".to_string() });
+}
+
+/// Check that multiple values involving null / no values cause an error
+#[test]
+fn empty_values_multi_values_error() {
+    #[derive(Deserialize, Debug, PartialEq)]
+    struct Query {
+        a: String,
+    }
+
+    let config =
+        serde_qs::Config::new().duplicate_key_behavior(serde_qs::DuplicateKeyBehavior::Error);
+
+    for input in ["a=&a=hello", "a&a=hello", "a=hello&a=", "a=hello&a"] {
+        deserialize_test_err_with_config::<Query>(
+            input,
+            "multiple values provided for non-sequence field",
+            config,
+        );
+
+        deserialize_test_err_with_config::<Query>(
+            input,
+            "multiple values provided for non-sequence field",
+            config,
+        );
+    }
+}


### PR DESCRIPTION
Fixes #171 

I'm not 100% sure that the fix doesn't cause a regression because I'm not familiar with the codebase, however from what I've seen it intuitively feels like the correct way to do this.