### PR TITLE
fix: percent-encode `%` in default query-string mode

### DIFF
--- a/src/ser/encode.rs
+++ b/src/ser/encode.rs
@@ -23,6 +23,9 @@ const MINIMAL_QS_SET: &AsciiSet = &percent_encoding::CONTROLS
     .add(b'<')
     .add(b'>')
     // control characters used in querystrings
+    // `%` introduces a percent-escape, so a literal `%` must itself be
+    // escaped -- otherwise e.g. the value `%41` would decode back as `A`
+    .add(b'%')
     // `+` is used to represent a space in query strings
     .add(b'+')
     // denote nested keys

--- a/tests/snapshots/edge_case_primitives@form.snap
+++ b/tests/snapshots/edge_case_primitives@form.snap
@@ -1,10 +1,12 @@
 ---
 source: tests/test_roundtrip.rs
-description: "EdgeCasePrimitives { empty_string: \"\", zero_int: 0, zero_float: 0.0, false_bool: false, space_string: \"   \", special_chars: \"!@#$%^&*()_+-=[]{}|;':,.<>?/~`\" }"
+description: "EdgeCasePrimitives { empty_string: \"\", zero_int: 0, zero_float: 0.0, false_bool: false, space_string: \"   \", special_chars: \"!@#$%^&*()_+-=[]{}|;':,.<>?/~`\", percent_escapes: \"%41 100%25 %5Bx%5D %AD0\" }"
+snapshot_kind: text
 ---
 empty_string=&
 zero_int=0&
 zero_float=0.0&
 false_bool=false&
 space_string=%20%20%20&
-special_chars=%21%40%23%24%25%5E%26*%28%29_%2B-%3D%5B%5D%7B%7D%7C%3B%27%3A%2C.%3C%3E%3F%2F%7E%60
+special_chars=%21%40%23%24%25%5E%26*%28%29_%2B-%3D%5B%5D%7B%7D%7C%3B%27%3A%2C.%3C%3E%3F%2F%7E%60&
+percent_escapes=%2541%20100%2525%20%255Bx%255D%20%25AD0

--- a/tests/snapshots/edge_case_primitives@query.snap
+++ b/tests/snapshots/edge_case_primitives@query.snap
@@ -1,10 +1,12 @@
 ---
 source: tests/test_roundtrip.rs
-description: "EdgeCasePrimitives { empty_string: \"\", zero_int: 0, zero_float: 0.0, false_bool: false, space_string: \"   \", special_chars: \"!@#$%^&*()_+-=[]{}|;':,.<>?/~`\" }"
+description: "EdgeCasePrimitives { empty_string: \"\", zero_int: 0, zero_float: 0.0, false_bool: false, space_string: \"   \", special_chars: \"!@#$%^&*()_+-=[]{}|;':,.<>?/~`\", percent_escapes: \"%41 100%25 %5Bx%5D %AD0\" }"
+snapshot_kind: text
 ---
 empty_string=&
 zero_int=0&
 zero_float=0.0&
 false_bool=false&
 space_string=+++&
-special_chars=!@%23$%^%26*()_%2B-%3D%5B%5D{}|;':,.%3C%3E?/~`
+special_chars=!@%23$%25^%26*()_%2B-%3D%5B%5D{}|;':,.%3C%3E?/~`&
+percent_escapes=%2541+100%2525+%255Bx%255D+%25AD0

--- a/tests/test_regression.rs
+++ b/tests/test_regression.rs
@@ -46,3 +46,64 @@ fn skipped_compound_fields_do_not_fail_index_check() {
     assert_eq!(decoded.example.get(&123), Some(&321));
     assert_eq!(decoded.unrelated, 0);
 }
+
+/// https://github.com/samscott89/serde_qs/issues/170
+///
+/// The default (non-form) encoding set did not include `%`, so any `%` in a
+/// string value or map key was emitted raw and re-decoded on the way back.
+#[test]
+fn percent_signs_roundtrip() {
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct Q {
+        name: String,
+    }
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct W {
+        a: std::collections::BTreeMap<String, String>,
+    }
+
+    // values containing something that looks like a percent escape
+    for value in ["%41", "100%25", "a%3Db", "%5Bx%5D", "%AD0", "%c5", "50%"] {
+        let q = Q {
+            name: value.to_string(),
+        };
+        let encoded = serde_qs::to_string(&q).unwrap();
+        assert_eq!(
+            serde_qs::from_str::<Q>(&encoded).unwrap(),
+            q,
+            "value {value:?} did not roundtrip (encoded as {encoded:?})"
+        );
+    }
+
+    assert_eq!(
+        serde_qs::to_string(&Q {
+            name: "%41".to_string()
+        })
+        .unwrap(),
+        "name=%2541"
+    );
+
+    // map keys, too
+    let map_key = |key: &str| {
+        let mut m = std::collections::BTreeMap::new();
+        m.insert(key.to_string(), "1".to_string());
+        W { a: m }
+    };
+
+    for key in ["K%47", "%5Bx%5D", "[x]"] {
+        let w = map_key(key);
+        let encoded = serde_qs::to_string(&w).unwrap();
+        assert_eq!(
+            serde_qs::from_str::<W>(&encoded).unwrap(),
+            w,
+            "key {key:?} did not roundtrip (encoded as {encoded:?})"
+        );
+    }
+
+    // distinct keys must not collide
+    assert_ne!(
+        serde_qs::to_string(&map_key("[x]")).unwrap(),
+        serde_qs::to_string(&map_key("%5Bx%5D")).unwrap()
+    );
+}

--- a/tests/test_roundtrip.rs
+++ b/tests/test_roundtrip.rs
@@ -139,6 +139,7 @@ struct EdgeCasePrimitives {
     false_bool: bool,
     space_string: String,
     special_chars: String,
+    percent_escapes: String,
 }
 
 #[test]
@@ -150,6 +151,9 @@ fn edge_case_primitives() {
         false_bool: false,
         space_string: "   ".to_string(),
         special_chars: "!@#$%^&*()_+-=[]{}|;':,.<>?/~`".to_string(),
+        // `%` followed by hex digits: only round-trips if `%` is itself escaped.
+        // `%AD` would decode to a non-UTF-8 byte.
+        percent_escapes: "%41 100%25 %5Bx%5D %AD0".to_string(),
     });
 }
 


### PR DESCRIPTION
Fixes #170. Thanks @hey-jj for the very precise report — the root cause was exactly where you pointed.

## The bug

`MINIMAL_QS_SET` in `src/ser/encode.rs` never called `.add(b'%')`, so a literal `%` in a string value or map key was emitted raw in the default (non-form) mode. Anything that then looked like a percent escape got decoded on the way back in:

| input | round-tripped to |
|---|---|
| `"%41"` | `"A"` |
| `"100%25"` | `"100%"` |
| `"a%3Db"` | `"a=b"` |
| `"%AD0"` | `Err(Utf8(..))` — on the crate's own output |

It also broke the bracket escaping documented at `src/config.rs:120`: the distinct map keys `"[x]"` and `"%5Bx%5D"` both serialized to `a[%5Bx%5D]=1`, so `a[%5Bx%5D]=1` was ambiguous.

## The fix

One line — add `%` to the set. That makes `%5B`/`%5D` an unambiguous escape and restores the round-trip contract:

```
name=%2541          // "%41"
a[%5Bx%5D]=1        // { a: { "[x]": 1 } }
a[%255Bx%255D]=1    // { a: { "%5Bx%5D": 1 } }
```

Form encoding was already correct — `FORM_URLENCODED_SET` is built on `NON_ALPHANUMERIC`, which includes `%`.

## Tests

- New `percent_signs_roundtrip` regression test covering values, map keys, the non-UTF-8 cases, and the key collision.
- `edge_case_primitives` gains a `percent_escapes` field. As the issue notes, the existing literal `"!@#$%^&*()..."` missed this because `%` is followed by `^`, a non-hex byte — the new field uses `%` followed by hex digits. Confirmed it fails on the round-trip assertion without the one-line fix.
- Two snapshots updated (`%` → `%25`); full CI feature matrix, doctests, clippy and fmt all pass locally.

## Compatibility note

This changes serializer output for any value containing `%`. Anything that was previously round-tripping through `serde_qs` is unaffected (it was already corrupted); but a consumer that deliberately fed pre-encoded strings through the serializer and relied on the pass-through will now see them double-encoded. That pass-through was never a documented guarantee and was indistinguishable from the corruption above, so I think the patch bump is right — flagging it in case you disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)