### PR TITLE
chore: release v1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.1.3](https://github.com/samscott89/serde_qs/compare/v1.1.2...v1.1.3) - 2026-08-07
+
+### Fixed
+
+- percent-encode `%` in default query-string mode ([#173](https://github.com/samscott89/serde_qs/pull/173))
+
+### Other
+
+- multiple values including null return parsing error ([#172](https://github.com/samscott89/serde_qs/pull/172))
+
 ## [1.1.2](https://github.com/samscott89/serde_qs/compare/v1.1.1...v1.1.2) - 2026-05-15
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 name = "serde_qs"
 repository = "https://github.com/samscott89/serde_qs"
 readme = "README.md"
-version = "1.1.2"
+version = "1.1.3"
 rust-version = "1.85"
 
 [dependencies]


### PR DESCRIPTION



## 🤖 New release

* `serde_qs`: 1.1.2 -> 1.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.3](https://github.com/samscott89/serde_qs/compare/v1.1.2...v1.1.3) - 2026-08-07

### Fixed

- percent-encode `%` in default query-string mode ([#173](https://github.com/samscott89/serde_qs/pull/173))

### Other

- multiple values including null return parsing error ([#172](https://github.com/samscott89/serde_qs/pull/172))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).